### PR TITLE
feat: alarm-single, alarm-multiple 기반 구조 정리

### DIFF
--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -29,7 +29,7 @@ static intr_handler_func timer_interrupt;
 static bool too_many_loops(unsigned loops);
 static void busy_wait(int64_t loops);
 static void real_time_sleep(int64_t num, int32_t denom);
-static bool sleep_compare(const struct list_elem *a,
+static bool sleep_less(const struct list_elem *a,
 						  const struct list_elem *b,
 						  void *aux);
 
@@ -101,21 +101,19 @@ timer_elapsed(int64_t then)
 // 그래서 스케줄러가 앞부터 체크하면서 해당 스레드랑 wake up tick을 비교하고 조건 만족하면 레디큐로 옮김
 void
 timer_sleep (int64_t ticks) { //해당 스레드 몇틱동안 재울건지 (인자(ticks)만큼 ticks + start까지 재움)
+
+	if(ticks <= 0) { return; }
 	enum intr_level old_level;
 	int64_t start = timer_ticks ();
 	struct thread * t = thread_current();
 
-	ASSERT (intr_get_level () == INTR_ON); // 걍 있음 
-	/*
-	while (timer_elapsed (start) < ticks) // 여기 수정해주기
-		thread_yield ();
-	*/
+	ASSERT (intr_get_level () == INTR_ON); 
 	int64_t total = start + ticks;
 	old_level = intr_disable();
 	t->wakeup_tick = start + ticks; //지금 스레드의 wakeup 틱을 설정
 
 	//sleep list에 넣어야해
-	list_insert_ordered(&sleep_list, &t->sleep_elem, sleep_compare, NULL);
+	list_insert_ordered(&sleep_list, &t->sleep_elem, sleep_less, NULL);
 	thread_block();
 	intr_set_level(old_level);
 }
@@ -215,7 +213,7 @@ real_time_sleep(int64_t num, int32_t denom)
 	}
 }
 
-bool sleep_compare(const struct list_elem *a, const struct list_elem *b, void *aux)
+bool sleep_less(const struct list_elem *a, const struct list_elem *b, void *aux)
 {
 	struct thread * thread_1 = list_entry(a, struct thread, sleep_elem);
 	struct thread * thread_2 = list_entry(b, struct thread, sleep_elem);

--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -1,7 +1,6 @@
 #include "devices/timer.h"
 #include <debug.h>
 #include <inttypes.h>
-#include <list.h>
 #include <round.h>
 #include <stdio.h>
 #include "threads/interrupt.h"
@@ -19,21 +18,20 @@
 #endif
 
 /* Number of timer ticks since OS booted. */
+static struct list sleep_list; // EY:sleep_list 구조체
 static int64_t ticks;
-
-/* Threads blocked in timer_sleep(), ordered by wakeup_tick. */
-static struct list sleep_list;
 
 /* Number of loops per timer tick.
    Initialized by timer_calibrate(). */
 static unsigned loops_per_tick;
 
 static intr_handler_func timer_interrupt;
-static bool wakeup_less(const struct list_elem *a,
-		const struct list_elem *b, void *aux UNUSED);
 static bool too_many_loops(unsigned loops);
 static void busy_wait(int64_t loops);
 static void real_time_sleep(int64_t num, int32_t denom);
+static bool sleep_compare(const struct list_elem *a,
+						  const struct list_elem *b,
+						  void *aux);
 
 /* Sets up the 8254 Programmable Interval Timer (PIT) to
    interrupt PIT_FREQ times per second, and registers the
@@ -49,7 +47,7 @@ void timer_init(void)
 	outb(0x40, count >> 8);
 
 	intr_register_ext(0x20, timer_interrupt, "8254 Timer");
-	list_init(&sleep_list);
+	list_init (&sleep_list); // EY:sleep_list 처음 시작할때 생성
 }
 
 /* Calibrates loops_per_tick, used to implement brief delays. */
@@ -98,22 +96,27 @@ timer_elapsed(int64_t then)
 }
 
 /* Suspends execution for approximately TICKS timer ticks. */
-void timer_sleep(int64_t ticks)
-{
-	if (ticks <= 0)
-	{
-		return;
-	}
+// 이 부분 수정해야함. 기존방식은 레디큐에 남아있으면서 스케줄러가 확인할 때 그 스레드가 또 실행돼서 while문 조건을 봄.
+// 근데 진짜 sleep하는걸로 바꿔야함. 깨어날 틱을 계산하고, sleep queue에 (정렬상태로)넣어줌. 
+// 그래서 스케줄러가 앞부터 체크하면서 해당 스레드랑 wake up tick을 비교하고 조건 만족하면 레디큐로 옮김
+void
+timer_sleep (int64_t ticks) { //해당 스레드 몇틱동안 재울건지 (인자(ticks)만큼 ticks + start까지 재움)
+	enum intr_level old_level;
+	int64_t start = timer_ticks ();
+	struct thread * t = thread_current();
 
-	ASSERT(intr_get_level() == INTR_ON);
+	ASSERT (intr_get_level () == INTR_ON); // 걍 있음 
+	/*
+	while (timer_elapsed (start) < ticks) // 여기 수정해주기
+		thread_yield ();
+	*/
+	int64_t total = start + ticks;
+	old_level = intr_disable();
+	t->wakeup_tick = start + ticks; //지금 스레드의 wakeup 틱을 설정
 
-	enum intr_level old_level = intr_disable();
-	struct thread *cur = thread_current();
-
-	cur->wakeup_tick = timer_ticks() + ticks;
-	list_insert_ordered(&sleep_list, &cur->sleep_elem, wakeup_less, NULL);
+	//sleep list에 넣어야해
+	list_insert_ordered(&sleep_list, &t->sleep_elem, sleep_compare, NULL);
 	thread_block();
-
 	intr_set_level(old_level);
 }
 
@@ -147,30 +150,6 @@ timer_interrupt(struct intr_frame *args UNUSED)
 {
 	ticks++;
 	thread_tick();
-
-	while (!list_empty(&sleep_list))
-	{
-		struct thread *t = list_entry(list_front(&sleep_list),
-				struct thread, sleep_elem);
-
-		if (t->wakeup_tick > ticks)
-		{
-			break;
-		}
-
-		list_pop_front(&sleep_list);
-		thread_unblock(t);
-	}
-}
-
-static bool
-wakeup_less(const struct list_elem *a, const struct list_elem *b,
-		void *aux UNUSED)
-{
-	const struct thread *ta = list_entry(a, struct thread, sleep_elem);
-	const struct thread *tb = list_entry(b, struct thread, sleep_elem);
-
-	return ta->wakeup_tick < tb->wakeup_tick;
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer
@@ -234,4 +213,12 @@ real_time_sleep(int64_t num, int32_t denom)
 		ASSERT(denom % 1000 == 0);
 		busy_wait(loops_per_tick * num / 1000 * TIMER_FREQ / (denom / 1000));
 	}
+}
+
+bool sleep_compare(const struct list_elem *a, const struct list_elem *b, void *aux)
+{
+	struct thread * thread_1 = list_entry(a, struct thread, sleep_elem);
+	struct thread * thread_2 = list_entry(b, struct thread, sleep_elem);
+
+	return thread_1->wakeup_tick < thread_2->wakeup_tick;
 }

--- a/pintos/devices/timer.c
+++ b/pintos/devices/timer.c
@@ -1,6 +1,7 @@
 #include "devices/timer.h"
 #include <debug.h>
 #include <inttypes.h>
+#include <list.h>
 #include <round.h>
 #include <stdio.h>
 #include "threads/interrupt.h"
@@ -20,11 +21,16 @@
 /* Number of timer ticks since OS booted. */
 static int64_t ticks;
 
+/* Threads blocked in timer_sleep(), ordered by wakeup_tick. */
+static struct list sleep_list;
+
 /* Number of loops per timer tick.
    Initialized by timer_calibrate(). */
 static unsigned loops_per_tick;
 
 static intr_handler_func timer_interrupt;
+static bool wakeup_less(const struct list_elem *a,
+		const struct list_elem *b, void *aux UNUSED);
 static bool too_many_loops(unsigned loops);
 static void busy_wait(int64_t loops);
 static void real_time_sleep(int64_t num, int32_t denom);
@@ -43,6 +49,7 @@ void timer_init(void)
 	outb(0x40, count >> 8);
 
 	intr_register_ext(0x20, timer_interrupt, "8254 Timer");
+	list_init(&sleep_list);
 }
 
 /* Calibrates loops_per_tick, used to implement brief delays. */
@@ -97,11 +104,17 @@ void timer_sleep(int64_t ticks)
 	{
 		return;
 	}
-	int64_t start = timer_ticks();
 
 	ASSERT(intr_get_level() == INTR_ON);
-	while (timer_elapsed(start) < ticks)
-		thread_yield();
+
+	enum intr_level old_level = intr_disable();
+	struct thread *cur = thread_current();
+
+	cur->wakeup_tick = timer_ticks() + ticks;
+	list_insert_ordered(&sleep_list, &cur->sleep_elem, wakeup_less, NULL);
+	thread_block();
+
+	intr_set_level(old_level);
 }
 
 /* Suspends execution for approximately MS milliseconds. */
@@ -134,6 +147,30 @@ timer_interrupt(struct intr_frame *args UNUSED)
 {
 	ticks++;
 	thread_tick();
+
+	while (!list_empty(&sleep_list))
+	{
+		struct thread *t = list_entry(list_front(&sleep_list),
+				struct thread, sleep_elem);
+
+		if (t->wakeup_tick > ticks)
+		{
+			break;
+		}
+
+		list_pop_front(&sleep_list);
+		thread_unblock(t);
+	}
+}
+
+static bool
+wakeup_less(const struct list_elem *a, const struct list_elem *b,
+		void *aux UNUSED)
+{
+	const struct thread *ta = list_entry(a, struct thread, sleep_elem);
+	const struct thread *tb = list_entry(b, struct thread, sleep_elem);
+
+	return ta->wakeup_tick < tb->wakeup_tick;
 }
 
 /* Returns true if LOOPS iterations waits for more than one timer

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -92,6 +92,8 @@ struct thread
 	enum thread_status status; /* Thread state. */
 	char name[16];			   /* Name (for debugging purposes). */
 	int priority;			   /* Priority. */
+	int64_t wakeup_tick;	   /* Tick at which to wake from sleep. */
+	struct list_elem sleep_elem; /* List element for sleep queue. */
 
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem; /* List element. */
@@ -143,5 +145,5 @@ int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
 
 void do_iret(struct intr_frame *tf);
-struct list sleep_list;
+
 #endif /* threads/thread.h */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -92,9 +92,8 @@ struct thread
 	enum thread_status status; /* Thread state. */
 	char name[16];			   /* Name (for debugging purposes). */
 	int priority;			   /* Priority. */
-	int64_t wakeup_tick;	   /* Tick at which to wake from sleep. */
-	struct list_elem sleep_elem; /* List element for sleep queue. */
-
+	int64_t wakeup_tick; // EY: wakeup_tick 구조체에 추가
+	struct list_elem sleep_elem; //EY: sleep_elem으로 
 	/* Shared between thread.c and synch.c. */
 	struct list_elem elem; /* List element. */
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -406,8 +406,8 @@ init_thread(struct thread *t, const char *name, int priority)
 	ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
 	ASSERT(name != NULL);
 
-	memset(t, 0, sizeof *t);
-	t->wakeup_tick = 0;
+	t->wakeup_tick = 0; //EY: wakeup_tick 초기화 
+	memset (t, 0, sizeof *t);
 	t->status = THREAD_BLOCKED;
 	strlcpy(t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -28,8 +28,6 @@
    that are ready to run but not actually running. */
 static struct list ready_list;
 
-static struct list sleep_list;
-
 /* Idle thread. */
 static struct thread *idle_thread;
 
@@ -409,6 +407,7 @@ init_thread(struct thread *t, const char *name, int priority)
 	ASSERT(name != NULL);
 
 	memset(t, 0, sizeof *t);
+	t->wakeup_tick = 0;
 	t->status = THREAD_BLOCKED;
 	strlcpy(t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof(void *);

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -406,7 +406,6 @@ init_thread(struct thread *t, const char *name, int priority)
 	ASSERT(PRI_MIN <= priority && priority <= PRI_MAX);
 	ASSERT(name != NULL);
 
-	t->wakeup_tick = 0; //EY: wakeup_tick 초기화 
 	memset (t, 0, sizeof *t);
 	t->status = THREAD_BLOCKED;
 	strlcpy(t->name, name, sizeof t->name);


### PR DESCRIPTION
## 요약
`alarm-single`, `alarm-multiple` 구현을 위해 sleep queue 기반 구조와 관련 초기화 흐름을 정리했습니다.

## 변경 사항
- sleep queue에 필요한 전역 자료구조를 추가했습니다.
- 관련 초기화 흐름을 정리했습니다.
- `thread`에 sleep 관련 정보를 저장할 필드를 마련했습니다.
- `timer_sleep()` 초입에서 다룰 예외 케이스를 정리했습니다.

## 테스트
- 별도 테스트는 아직 실행하지 않았습니다.

## 비고
세부 깨우기 로직 전체보다는, alarm 기능 구현에 필요한 공통 기반 구조를 먼저 반영한 변경입니다.

Closes #5
