### PR TITLE
feat: running thread 우선순위 변경 처리

### DIFF
--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -202,9 +202,12 @@ tid_t thread_create(const char *name, int priority,
 	t->tf.cs = SEL_KCSEG;
 	t->tf.eflags = FLAG_IF;
 
-	/* Add to run queue. */
+	//새로 만들었는데 우선순위 현재 러닝중인 스레드보다 높으면 러닝 스레드가 양보
 	thread_unblock(t);
-
+	if (t->priority > thread_current()->priority)
+	{
+		thread_yield();
+	}
 	return tid;
 }
 
@@ -323,7 +326,15 @@ void thread_yield(void)
 /* Sets the current thread's priority to NEW_PRIORITY. */
 void thread_set_priority(int new_priority)
 {
-	thread_current()->priority = new_priority;
+	thread_current()->priority = new_priority; 
+	if (!list_empty(&ready_list)) //새로운 우선순위가 들어왔는데, 우선순위가 러닝하던 스레드보다 높으면 양보하는 로직
+	{
+		struct list_elem * front = list_front(&ready_list); //front에 레디리스트 앞 스레드 넣어줌
+		if(list_entry(front, struct thread, elem)->priority > new_priority) // 레디리스트 앞스레드 > 현재 만들어진 스레드면
+		{
+			thread_yield(); //양보함
+		} 
+	}
 }
 
 /* Returns the current thread's priority. */


### PR DESCRIPTION
## 요약
스레드 우선순위가 바뀌거나 더 높은 우선순위의 스레드가 생성되는 경우, 현재 실행 중인 스레드가 적절히 양보하도록 처리했습니다.

## 변경 사항
- 새로 생성된 스레드의 우선순위가 현재 실행 중인 스레드보다 높으면 `thread_yield()`를 호출하도록 했습니다.
- `thread_set_priority()`에서 현재 스레드의 우선순위 변경 후 ready list의 더 높은 우선순위 스레드가 있으면 실행을 양보하도록 했습니다.

## 테스트
- 별도 테스트는 아직 실행하지 않았습니다.

## 비고
이번 PR은 `running_thread_change` 케이스를 중심으로 우선순위 변경 시점의 선점 흐름을 정리합니다.

Closes #11
