### PR TITLE
feat: priority_sema 테스트 통과를 위한 세마포어 우선순위 처리 개선

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -135,6 +135,7 @@ const char *thread_name(void);
 void thread_exit(void) NO_RETURN;
 void thread_yield(void);
 
+bool priority_higher(const struct list_elem *a_, const struct list_elem *b_, void *aux UNUSED);
 int thread_get_priority(void);
 void thread_set_priority(int);
 

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -69,7 +69,7 @@ sema_down (struct semaphore *sema)
 	old_level = intr_disable ();
 	while (sema->value == 0)
 	{
-		list_push_back (&sema->waiters, &thread_current ()->elem);
+		list_insert_ordered(&sema->waiters, &thread_current()->elem, priority_higher, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -110,15 +110,28 @@ void
 sema_up (struct semaphore *sema)
 {
 	enum intr_level old_level;
+	struct thread *unblocked_thread = NULL;
 
 	ASSERT (sema != NULL);
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters))
-		thread_unblock (
-			list_entry (list_pop_front (&sema->waiters), struct thread, elem));
+	if (!list_empty (&sema->waiters)){
+		//waiters에 있는 스레드들 우선순위 순서대로 다시 정렬
+		//한번 더 sort? => donation 고려
+		list_sort(&sema->waiters, priority_higher, NULL);
+		//가장 우선순위 높은 스레드를 waiters에서 꺼내줌
+		unblocked_thread = list_entry (list_pop_front (&sema->waiters), struct thread, elem);
+		//꺼낸 스레드를 ready_list에 넣어서 실행 가능한 상태로 바꿔줌
+		thread_unblock (unblocked_thread);
+	}
 	sema->value++;
 	intr_set_level (old_level);
+
+	//깨운 스레드가 있고, 그 스레드가 현재 스레드보다 우선순위가 높으면 양보해야함.
+	//waiters 에서 깨운 쓰레드가 없는데 그 priority에 접근하면 터짐.
+	if(unblocked_thread != NULL && unblocked_thread->priority > thread_current()->priority){
+		thread_yield();
+	}
 }
 
 static void sema_test_helper (void *sema_);

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -129,7 +129,8 @@ sema_up (struct semaphore *sema)
 
 	//깨운 스레드가 있고, 그 스레드가 현재 스레드보다 우선순위가 높으면 양보해야함.
 	//waiters 에서 깨운 쓰레드가 없는데 그 priority에 접근하면 터짐.
-	if(unblocked_thread != NULL && unblocked_thread->priority > thread_current()->priority){
+	if(unblocked_thread != NULL && !intr_context () && 
+			unblocked_thread->priority > thread_current()->priority){
 		thread_yield();
 	}
 }

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -60,14 +60,14 @@ void sema_init(struct semaphore *sema, unsigned value)
 void sema_down(struct semaphore *sema)
 {
 	enum intr_level old_level;
-
+	
 	ASSERT(sema != NULL);
 	ASSERT(!intr_context());
 
 	old_level = intr_disable();
 	while (sema->value == 0)
 	{
-		list_push_back(&sema->waiters, &thread_current()->elem);
+		list_insert_ordered(&sema->waiters, &thread_current()->elem, priority_higher, NULL);
 		thread_block();
 	}
 	sema->value--;

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -231,7 +231,7 @@ void thread_block(void)
    it may expect that it can atomically unblock a thread and
    update other data. */
 
-static bool
+bool
 priority_higher(const struct list_elem *a_, const struct list_elem *b_,
 				void *aux UNUSED)
 {

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -238,7 +238,7 @@ thread_block (void)
    it may expect that it can atomically unblock a thread and
    update other data. */
 
-static bool
+bool
 priority_higher (const struct list_elem *a_, const struct list_elem *b_,
 				 void *aux UNUSED)
 {


### PR DESCRIPTION
﻿## 요약
priority_sema 테스트가 기대하는 우선순위 기반 wake-up 동작을 만족하도록 세마포어 우선순위 처리 흐름을 정리했습니다.

## 변경 사항
- 세마포어 해제 시 대기 중인 스레드가 우선순위 순서에 맞게 깨어나도록 처리 기준을 보완했습니다.
- 우선순위 스케줄링 흐름이 priority_sema 테스트의 기대 순서와 맞도록 동작을 점검했습니다.

## 테스트
- `priority-sema`: PASS

## 비고
- Base branch: `dev`
- 이번 PR의 테스트 확인 범위는 `priority-sema`입니다.

Closes #9
