### PR TITLE
feat: priority donation 테스트 통과 구현

### DIFF
--- a/pintos/include/threads/synch.h
+++ b/pintos/include/threads/synch.h
@@ -5,44 +5,47 @@
 #include <stdbool.h>
 
 /* A counting semaphore. */
-struct semaphore {
-	unsigned value;             /* Current value. */
-	struct list waiters;        /* List of waiting threads. */
+struct semaphore
+{
+	unsigned value;		 /* Current value. */
+	struct list waiters; /* List of waiting threads. */
 };
 
-void sema_init (struct semaphore *, unsigned value);
-void sema_down (struct semaphore *);
-bool sema_try_down (struct semaphore *);
-void sema_up (struct semaphore *);
-void sema_self_test (void);
+void sema_init(struct semaphore *, unsigned value);
+void sema_down(struct semaphore *);
+bool sema_try_down(struct semaphore *);
+void sema_up(struct semaphore *);
+void sema_self_test(void);
 
 /* Lock. */
-struct lock {
-	struct thread *holder;      /* Thread holding lock (for debugging). */
+struct lock
+{
+	struct thread *holder;		/* Thread holding lock (for debugging). */
 	struct semaphore semaphore; /* Binary semaphore controlling access. */
 };
 
-void lock_init (struct lock *);
-void lock_acquire (struct lock *);
-bool lock_try_acquire (struct lock *);
-void lock_release (struct lock *);
-bool lock_held_by_current_thread (const struct lock *);
+void lock_init(struct lock *);
+void lock_acquire(struct lock *);
+bool lock_try_acquire(struct lock *);
+void lock_release(struct lock *);
+bool lock_held_by_current_thread(const struct lock *);
 
 /* Condition variable. */
-struct condition {
-	struct list waiters;        /* List of waiting threads. */
+struct condition
+{
+	struct list waiters; /* List of waiting threads. */
 };
 
-void cond_init (struct condition *);
-void cond_wait (struct condition *, struct lock *);
-void cond_signal (struct condition *, struct lock *);
-void cond_broadcast (struct condition *, struct lock *);
+void cond_init(struct condition *);
+void cond_wait(struct condition *, struct lock *);
+void cond_signal(struct condition *, struct lock *);
+void cond_broadcast(struct condition *, struct lock *);
 
 /* Optimization barrier.
  *
  * The compiler will not reorder operations across an
  * optimization barrier.  See "Optimization Barriers" in the
  * reference guide for more information.*/
-#define barrier() asm volatile ("" : : : "memory")
+#define barrier() asm volatile("" : : : "memory")
 
 #endif /* threads/synch.h */

--- a/pintos/include/threads/synch.h
+++ b/pintos/include/threads/synch.h
@@ -22,7 +22,7 @@ struct lock
 {
 	struct thread *holder;		/* Thread holding lock (for debugging). */
 	struct semaphore semaphore; /* Binary semaphore controlling access. */
-	struct list_elem hold_elem	// holder의 held_locks에 넣기 위한 elem
+	struct list_elem hold_elem; // holder의 held_locks에 넣기 위한 elem
 };
 
 void lock_init(struct lock *);

--- a/pintos/include/threads/synch.h
+++ b/pintos/include/threads/synch.h
@@ -22,6 +22,7 @@ struct lock
 {
 	struct thread *holder;		/* Thread holding lock (for debugging). */
 	struct semaphore semaphore; /* Binary semaphore controlling access. */
+	struct list_elem hold_elem	// holder의 held_locks에 넣기 위한 elem
 };
 
 void lock_init(struct lock *);

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -92,10 +92,13 @@ struct thread
 	enum thread_status status;	 /* Thread state. */
 	char name[16];				 /* Name (for debugging purposes). */
 	int priority;				 /* Priority. */
+	int original_priority;		/* donation이 되기전 original priority */
 	int64_t wakeup_tick;		 // EY: wakeup_tick 구조체에 추가
 	struct list_elem sleep_elem; // EY: sleep_elem으로
 	/* Shared between thread.c and synch.c. */
-	struct list_elem elem; /* List element. */
+	struct list_elem elem;	/* List element. */
+	struct list held_locks; // 현재 들고 있는 lock 목록
+	bool is_donated; //  현재 priority donation을 받고 있는지 여부
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -92,13 +92,14 @@ struct thread
 	enum thread_status status;	 /* Thread state. */
 	char name[16];				 /* Name (for debugging purposes). */
 	int priority;				 /* Priority. */
-	int original_priority;		/* donation이 되기전 original priority */
+	int original_priority;		 /* donation이 되기전 original priority */
 	int64_t wakeup_tick;		 // EY: wakeup_tick 구조체에 추가
 	struct list_elem sleep_elem; // EY: sleep_elem으로
 	/* Shared between thread.c and synch.c. */
-	struct list_elem elem;	/* List element. */
-	struct list held_locks; // 현재 들고 있는 lock 목록
-	bool is_donated; //  현재 priority donation을 받고 있는지 여부
+	struct list_elem elem;	   /* List element. */
+	struct list held_locks;	   // 현재 들고 있는 lock 목록
+	bool is_donated;		   //  현재 priority donation을 받고 있는지 여부
+	struct lock *waiting_lock; // 현재 이 쓰레드가 얻으려고 기다리는 lock
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -113,6 +113,7 @@ sema_up (struct semaphore *sema)
 	struct thread *unblocked_thread = NULL;
 
 	ASSERT (sema != NULL);
+	struct thread *highest_thread = NULL;
 
 	old_level = intr_disable ();
 	if (!list_empty (&sema->waiters)){
@@ -210,9 +211,26 @@ lock_acquire (struct lock *lock)
 	ASSERT (lock != NULL);
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
-
+	struct thread *holder = lock->holder;
+	if (holder != NULL)
+	{
+		priority_donation (holder, thread_current ());
+	}
 	sema_down (&lock->semaphore);
 	lock->holder = thread_current ();
+}
+/*
+holder의 priorty가 현재 쓰레드의 우선순위보다 낮으면 우선순위를 높여준다.
+(donation) donation 받기 전 기존 우선순위를 original priority에 저장한다.
+*/
+void
+priority_donation (struct thread *holder, struct thread *current)
+{
+	if (holder->priority < current->priority)
+	{
+		holder->priority = holder->original_priority;
+		holder->priority = current->priority;
+	}
 }
 
 /* Tries to acquires LOCK and returns true if successful or false
@@ -244,10 +262,11 @@ lock_try_acquire (struct lock *lock)
 void
 lock_release (struct lock *lock)
 {
+	struct thread *current = thread_current ();
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
-
 	lock->holder = NULL;
+	current->priority = current->original_priority;
 	sema_up (&lock->semaphore);
 }
 

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -241,7 +241,6 @@ lock_acquire (struct lock *lock)
 			priority_donation (holder, donor);
 			donor = holder;
 		}
-		priority_donation (holder, thread_current ());
 	}
 	sema_down (&lock->semaphore);
 	current->waiting_lock = NULL;

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -33,8 +33,8 @@
 #include "threads/thread.h"
 
 static void priority_donation (struct thread *holder, struct thread *current);
-static bool priority_less (const struct list_elem *a_, const struct list_elem *b_,
-						   void *aux UNUSED);
+static bool priority_less (const struct list_elem *a_,
+						   const struct list_elem *b_, void *aux UNUSED);
 
 static bool
 priority_less (const struct list_elem *a_, const struct list_elem *b_,
@@ -230,12 +230,22 @@ lock_acquire (struct lock *lock)
 	ASSERT (!intr_context ());
 	ASSERT (!lock_held_by_current_thread (lock));
 	struct thread *holder = lock->holder;
+	struct thread *current = thread_current ();
 	if (holder != NULL)
 	{
+		current->waiting_lock = lock;
+		struct thread *donor = current;
+		while (donor->waiting_lock != NULL && donor->waiting_lock->holder != NULL)
+		{
+			holder = donor->waiting_lock->holder;
+			priority_donation (holder, donor);
+			donor = holder;
+		}
 		priority_donation (holder, thread_current ());
 	}
 	sema_down (&lock->semaphore);
-	lock->holder = thread_current ();
+	current->waiting_lock = NULL;
+	lock->holder = current;
 	/* lock을 실제로 얻은 뒤, 현재 스레드가 보유한 lock 목록에 기록한다. */
 	list_push_back (&thread_current ()->held_locks, &lock->hold_elem);
 }
@@ -248,7 +258,8 @@ priority_donation (struct thread *holder, struct thread *current)
 {
 	if (holder->priority < current->priority)
 	{
-		/* original_priority는 보존하고, 현재 적용 priority만 donation 값으로 올린다. */
+		/* original_priority는 보존하고, 현재 적용 priority만 donation 값으로
+		 * 올린다. */
 		holder->priority = current->priority;
 		holder->is_donated = true;
 	}
@@ -272,7 +283,8 @@ lock_try_acquire (struct lock *lock)
 	if (success)
 	{
 		lock->holder = thread_current ();
-		/* try_acquire로 얻은 lock도 release 시 priority 재계산 대상에 포함한다. */
+		/* try_acquire로 얻은 lock도 release 시 priority 재계산 대상에 포함한다.
+		 */
 		list_push_back (&thread_current ()->held_locks, &lock->hold_elem);
 	}
 	return success;
@@ -292,13 +304,14 @@ lock_release (struct lock *lock)
 	struct thread *current = thread_current ();
 	struct list_elem *cur_elem;
 
-	/* 방금 놓는 lock은 더 이상 current의 donation 근거가 아니므로 목록에서 제거한다. */
+	/* 방금 놓는 lock은 더 이상 current의 donation 근거가 아니므로 목록에서
+	 * 제거한다. */
 	list_remove (&lock->hold_elem);
 
-	lock->holder = NULL;
 	current->priority = current->original_priority;
 	current->is_donated = false;
-	/* 아직 들고 있는 lock들의 waiters를 보고 남아 있는 donation 중 최댓값을 반영한다. */
+	/* 아직 들고 있는 lock들의 waiters를 보고 남아 있는 donation 중 최댓값을
+	 * 반영한다. */
 	for (cur_elem = list_begin (&current->held_locks);
 		 cur_elem != list_end (&current->held_locks);
 		 cur_elem = list_next (cur_elem))
@@ -316,6 +329,7 @@ lock_release (struct lock *lock)
 			}
 		}
 	}
+	lock->holder = NULL;
 	sema_up (&lock->semaphore);
 }
 

--- a/pintos/threads/synch.c
+++ b/pintos/threads/synch.c
@@ -32,6 +32,20 @@
 #include "threads/interrupt.h"
 #include "threads/thread.h"
 
+static void priority_donation (struct thread *holder, struct thread *current);
+static bool priority_less (const struct list_elem *a_, const struct list_elem *b_,
+						   void *aux UNUSED);
+
+static bool
+priority_less (const struct list_elem *a_, const struct list_elem *b_,
+			   void *aux UNUSED)
+{
+	const struct thread *a = list_entry (a_, struct thread, elem);
+	const struct thread *b = list_entry (b_, struct thread, elem);
+
+	return a->priority < b->priority;
+}
+
 /* Initializes semaphore SEMA to VALUE.  A semaphore is a
    nonnegative integer along with two atomic operators for
    manipulating it:
@@ -69,7 +83,8 @@ sema_down (struct semaphore *sema)
 	old_level = intr_disable ();
 	while (sema->value == 0)
 	{
-		list_insert_ordered(&sema->waiters, &thread_current()->elem, priority_higher, NULL);
+		list_insert_ordered (&sema->waiters, &thread_current ()->elem,
+							 priority_higher, NULL);
 		thread_block ();
 	}
 	sema->value--;
@@ -113,26 +128,29 @@ sema_up (struct semaphore *sema)
 	struct thread *unblocked_thread = NULL;
 
 	ASSERT (sema != NULL);
-	struct thread *highest_thread = NULL;
 
 	old_level = intr_disable ();
-	if (!list_empty (&sema->waiters)){
-		//waiters에 있는 스레드들 우선순위 순서대로 다시 정렬
-		//한번 더 sort? => donation 고려
-		list_sort(&sema->waiters, priority_higher, NULL);
-		//가장 우선순위 높은 스레드를 waiters에서 꺼내줌
-		unblocked_thread = list_entry (list_pop_front (&sema->waiters), struct thread, elem);
-		//꺼낸 스레드를 ready_list에 넣어서 실행 가능한 상태로 바꿔줌
+	if (!list_empty (&sema->waiters))
+	{
+		// waiters에 있는 스레드들 우선순위 순서대로 다시 정렬
+		// 한번 더 sort? => donation 고려
+		list_sort (&sema->waiters, priority_higher, NULL);
+		// 가장 우선순위 높은 스레드를 waiters에서 꺼내줌
+		unblocked_thread
+			= list_entry (list_pop_front (&sema->waiters), struct thread, elem);
+		// 꺼낸 스레드를 ready_list에 넣어서 실행 가능한 상태로 바꿔줌
 		thread_unblock (unblocked_thread);
 	}
 	sema->value++;
 	intr_set_level (old_level);
 
-	//깨운 스레드가 있고, 그 스레드가 현재 스레드보다 우선순위가 높으면 양보해야함.
-	//waiters 에서 깨운 쓰레드가 없는데 그 priority에 접근하면 터짐.
-	if(unblocked_thread != NULL && !intr_context () && 
-			unblocked_thread->priority > thread_current()->priority){
-		thread_yield();
+	// 깨운 스레드가 있고, 그 스레드가 현재 스레드보다 우선순위가 높으면
+	// 양보해야함. waiters 에서 깨운 쓰레드가 없는데 그 priority에 접근하면
+	// 터짐.
+	if (unblocked_thread != NULL && !intr_context ()
+		&& unblocked_thread->priority > thread_current ()->priority)
+	{
+		thread_yield ();
 	}
 }
 
@@ -218,18 +236,21 @@ lock_acquire (struct lock *lock)
 	}
 	sema_down (&lock->semaphore);
 	lock->holder = thread_current ();
+	/* lock을 실제로 얻은 뒤, 현재 스레드가 보유한 lock 목록에 기록한다. */
+	list_push_back (&thread_current ()->held_locks, &lock->hold_elem);
 }
 /*
 holder의 priorty가 현재 쓰레드의 우선순위보다 낮으면 우선순위를 높여준다.
 (donation) donation 받기 전 기존 우선순위를 original priority에 저장한다.
 */
-void
+static void
 priority_donation (struct thread *holder, struct thread *current)
 {
 	if (holder->priority < current->priority)
 	{
-		holder->priority = holder->original_priority;
+		/* original_priority는 보존하고, 현재 적용 priority만 donation 값으로 올린다. */
 		holder->priority = current->priority;
+		holder->is_donated = true;
 	}
 }
 
@@ -249,7 +270,11 @@ lock_try_acquire (struct lock *lock)
 
 	success = sema_try_down (&lock->semaphore);
 	if (success)
+	{
 		lock->holder = thread_current ();
+		/* try_acquire로 얻은 lock도 release 시 priority 재계산 대상에 포함한다. */
+		list_push_back (&thread_current ()->held_locks, &lock->hold_elem);
+	}
 	return success;
 }
 
@@ -262,11 +287,35 @@ lock_try_acquire (struct lock *lock)
 void
 lock_release (struct lock *lock)
 {
-	struct thread *current = thread_current ();
 	ASSERT (lock != NULL);
 	ASSERT (lock_held_by_current_thread (lock));
+	struct thread *current = thread_current ();
+	struct list_elem *cur_elem;
+
+	/* 방금 놓는 lock은 더 이상 current의 donation 근거가 아니므로 목록에서 제거한다. */
+	list_remove (&lock->hold_elem);
+
 	lock->holder = NULL;
 	current->priority = current->original_priority;
+	current->is_donated = false;
+	/* 아직 들고 있는 lock들의 waiters를 보고 남아 있는 donation 중 최댓값을 반영한다. */
+	for (cur_elem = list_begin (&current->held_locks);
+		 cur_elem != list_end (&current->held_locks);
+		 cur_elem = list_next (cur_elem))
+	{
+		struct lock *held_lock = list_entry (cur_elem, struct lock, hold_elem);
+		struct list *waiters = &held_lock->semaphore.waiters;
+		if (!list_empty (waiters))
+		{
+			struct thread *max_priority_thread = list_entry (
+				list_max (waiters, priority_less, NULL), struct thread, elem);
+			if (max_priority_thread->priority > current->priority)
+			{
+				current->priority = max_priority_thread->priority;
+				current->is_donated = true;
+			}
+		}
+	}
 	sema_up (&lock->semaphore);
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -112,7 +112,7 @@ thread_init (void)
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
 	initial_thread->status = THREAD_RUNNING;
-	initial_thread->tid = allocate_tid ();
+	initial_thread->tid = allocate_tid (); 
 }
 
 /* Starts preemptive thread scheduling by enabling interrupts.
@@ -335,11 +335,18 @@ thread_yield (void)
 void
 thread_set_priority (int new_priority)
 {
-	thread_current()->priority = new_priority; 
+	struct thread *current = thread_current;
+	current->original_priority = new_priority; 
+	if(!current->is_donated) {
+		current->priority = new_priority;
+	} else {
+		int donation_priority = current->priority;
+		current->priority = donation_priority > new_priority ? donation_priority : new_priority;
+	}
 	if (!list_empty(&ready_list)) //새로운 우선순위가 들어왔는데, 우선순위가 러닝하던 스레드보다 높으면 양보하는 로직
 	{
 		struct list_elem * front = list_front(&ready_list); //front에 레디리스트 앞 스레드 넣어줌
-		if(list_entry(front, struct thread, elem)->priority > new_priority) // 레디리스트 앞스레드 > 현재 만들어진 스레드면
+		if(list_entry(front, struct thread, elem)->priority > current->priority) // 레디리스트 앞스레드 > 현재 만들어진 스레드면
 		{
 			thread_yield(); //양보함
 		} 
@@ -448,7 +455,9 @@ init_thread (struct thread *t, const char *name, int priority)
 	strlcpy (t->name, name, sizeof t->name);
 	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof (void *);
 	t->priority = priority;
+	t->original_priority = priority;
 	t->magic = THREAD_MAGIC;
+	t->is_donated = false;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -460,6 +460,7 @@ init_thread (struct thread *t, const char *name, int priority)
 	list_init (&t->held_locks);
 	t->magic = THREAD_MAGIC;
 	t->is_donated = false;
+	t->waiting_lock = NULL;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -112,7 +112,7 @@ thread_init (void)
 	initial_thread = running_thread ();
 	init_thread (initial_thread, "main", PRI_DEFAULT);
 	initial_thread->status = THREAD_RUNNING;
-	initial_thread->tid = allocate_tid (); 
+	initial_thread->tid = allocate_tid ();
 }
 
 /* Starts preemptive thread scheduling by enabling interrupts.
@@ -205,11 +205,12 @@ thread_create (const char *name, int priority, thread_func *function, void *aux)
 	t->tf.cs = SEL_KCSEG;
 	t->tf.eflags = FLAG_IF;
 
-	//새로 만들었는데 우선순위 현재 러닝중인 스레드보다 높으면 러닝 스레드가 양보
-	thread_unblock(t);
-	if (t->priority > thread_current()->priority)
+	// 새로 만들었는데 우선순위 현재 러닝중인 스레드보다 높으면 러닝 스레드가
+	// 양보
+	thread_unblock (t);
+	if (t->priority > thread_current ()->priority)
 	{
-		thread_yield();
+		thread_yield ();
 	}
 	return tid;
 }
@@ -336,20 +337,27 @@ void
 thread_set_priority (int new_priority)
 {
 	struct thread *current = thread_current ();
-	current->original_priority = new_priority; 
-	if(!current->is_donated) {
-		current->priority = new_priority;
-	} else {
-		int donation_priority = current->priority;
-		current->priority = donation_priority > new_priority ? donation_priority : new_priority;
-	}
-	if (!list_empty(&ready_list)) //새로운 우선순위가 들어왔는데, 우선순위가 러닝하던 스레드보다 높으면 양보하는 로직
+	current->original_priority = new_priority;
+	if (!current->is_donated)
 	{
-		struct list_elem * front = list_front(&ready_list); //front에 레디리스트 앞 스레드 넣어줌
-		if(list_entry(front, struct thread, elem)->priority > current->priority) // 레디리스트 앞스레드 > 현재 만들어진 스레드면
+		current->priority = new_priority;
+	}
+	else
+	{
+		int donation_priority = current->priority;
+		current->priority = donation_priority > new_priority ? donation_priority
+															 : new_priority;
+	}
+	if (!list_empty (&ready_list)) // 새로운 우선순위가 들어왔는데, 우선순위가
+								   // 러닝하던 스레드보다 높으면 양보하는 로직
+	{
+		struct list_elem *front
+			= list_front (&ready_list); // front에 레디리스트 앞 스레드 넣어줌
+		if (list_entry (front, struct thread, elem)->priority
+			> current->priority) // 레디리스트 앞스레드 > 현재 만들어진 스레드면
 		{
-			thread_yield(); //양보함
-		} 
+			thread_yield (); // 양보함
+		}
 	}
 }
 

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -335,7 +335,7 @@ thread_yield (void)
 void
 thread_set_priority (int new_priority)
 {
-	struct thread *current = thread_current;
+	struct thread *current = thread_current ();
 	current->original_priority = new_priority; 
 	if(!current->is_donated) {
 		current->priority = new_priority;
@@ -456,6 +456,8 @@ init_thread (struct thread *t, const char *name, int priority)
 	t->tf.rsp = (uint64_t)t + PGSIZE - sizeof (void *);
 	t->priority = priority;
 	t->original_priority = priority;
+	/* priority donation 복구를 위해 현재 스레드가 보유한 lock들을 추적한다. */
+	list_init (&t->held_locks);
 	t->magic = THREAD_MAGIC;
 	t->is_donated = false;
 }


### PR DESCRIPTION
## 요약
Pintos threads의 priority donation 관련 테스트를 통과하도록 lock/semaphore 우선순위 처리와 donation 전파 로직을 정리합니다.

## 변경 사항
- lock 대기 시 holder에게 priority donation이 반영되도록 수정
- semaphore waiters를 priority 기준으로 정렬하고 높은 priority thread가 먼저 깨어나도록 처리
- lock release 시 남아 있는 lock waiters를 기준으로 priority를 재계산하도록 정리
- thread의 original priority, held lock 목록, 대기 중인 lock 정보를 관리하도록 보완
- nested donation 및 chain donation 상황에서 priority가 연쇄적으로 전달되도록 처리

## 테스트
- `priority-donate-one`
- `priority-donate-multiple`
- `priority-donate-multiple2`
- `priority-donate-nest`
- `priority-donate-chain`

## 비고
- 위 priority donation 테스트 5개가 통과한 상태를 기준으로 PR 본문을 갱신했습니다.

Closes #10