### PR TITLE
feat: sys_halt 및 sys_exit 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -131,6 +131,12 @@ struct thread
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4; /* Page map level 4 */
+	/*
+		그냥 status에 exit status를 저장하면 안된다고 한다.
+		status 는 스레드가 실행 중인지/죽는 중인지 의 상태를 저장하는 곳이고,
+		exit_status를 따로 할당해서 프로그램이 exit(int)로 종료했다 의 상태를 저장하는 곳이다.
+	*/
+	int exit_status;
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -223,6 +223,12 @@ void process_exit(void)
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
 
+	/*
+		프로세스가 종료될 때 출력해야 하는 메시지를 구현해라.
+		process_termination.html 을 참고하라.
+		exit: exit(57) 가 출력되어야 함.
+	*/
+	printf("%s: exit(%d)\n", curr->name, curr->exit_status);
 	process_cleanup();
 }
 
@@ -371,7 +377,6 @@ load(const char *file_name, struct intr_frame *if_)
 		argc++;
 	}
 
-	printf("argc : %d\n", argc);
 	// for(int i = 0; i < argc + 1; i++)
 	// {
 	// 	if(file_name_arg[i] != NULL){

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -8,6 +8,7 @@
 #include "threads/flags.h"
 #include "intrinsic.h"
 #include "kernel/stdio.h"
+#include "threads/init.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -45,10 +46,22 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	uint64_t sys_type = f->R.rax; 
 
 	switch(sys_type){
-		case SYS_HALT:
+		/*
+			Pintos를 종료하는 syscall
+			power_off() 를 호출하면 됨.
+		*/
+		case SYS_HALT: 
+			power_off();
 			break;
-
+		/*
+			현재 user program을 종료하고, 종료 상태 값을 커널에 남긴다.
+			부모가 wait 하면 이 status 값을 받아야 한다. 
+			관례적으로 0 = 성공, 0 이 아닌 값 = 실패
+		*/
 		case SYS_EXIT:
+			struct thread *curr = thread_current();
+			curr->exit_status = f->R.rdi;
+			thread_exit();
 			break;
 
 		case SYS_FORK:
@@ -101,5 +114,5 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	}
 
 	printf("system call!\n");
-	thread_exit();
+	//thread_exit();
 }


### PR DESCRIPTION
﻿## 요약
`sys_halt`와 `sys_exit` 시스템 콜 동작을 구현했습니다.

## 변경 사항
- 시스템 종료 요청을 처리하는 `sys_halt` 경로를 연결했습니다.
- 프로세스 종료 요청을 처리하는 `sys_exit` 경로를 구현했습니다.
- 종료 코드 및 종료 흐름이 일관되게 이어지도록 관련 처리 지점을 정리했습니다.

## 테스트
- 별도 테스트는 아직 수행하지 않았습니다.

## 비고
이번 PR은 `feat-#19`를 기준으로 추가된 시스템 콜 구현만 포함하도록 base를 `feat-#19`로 설정했습니다.

Closes #22
