### PR TITLE
feat: sys_halt 및 sys_exit 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -131,6 +131,12 @@ struct thread
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4; /* Page map level 4 */
+	/*
+		그냥 status에 exit status를 저장하면 안된다고 한다.
+		status 는 스레드가 실행 중인지/죽는 중인지 의 상태를 저장하는 곳이고,
+		exit_status를 따로 할당해서 프로그램이 exit(int)로 종료했다 의 상태를 저장하는 곳이다.
+	*/
+	int exit_status;
 #endif
 #ifdef VM
 	/* Table for whole virtual memory owned by thread. */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -179,8 +179,6 @@ int thread_get_nice(void);
 void thread_set_nice(int);
 int thread_get_recent_cpu(void);
 int thread_get_load_avg(void);
-void calc_one_tick(); //recent_cpu++
-void calc_four_tick(); //priority재계산
 
 void do_iret(struct intr_frame *tf);
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -356,9 +356,9 @@ load(const char *file_name, struct intr_frame *if_)
 
 	char *file_name_copy = (char *) palloc_get_page(0);
 	char *command_line = file_name;
-	char **file_name_arg = (char **)palloc_get_page(0);
+	char **file_name_arg = palloc_get_page(0);
 	char *save_ptr;
-
+	
 	strlcpy(file_name_copy, file_name, PGSIZE);
 
 	char *program_name = strtok_r(file_name_copy, " ", &save_ptr);
@@ -371,11 +371,15 @@ load(const char *file_name, struct intr_frame *if_)
 		argc++;
 	}
 
-	printf("나여: argc. %d\n", argc);
-	for(int i = 0; i < argc; i++)
-	{
-		printf("나여 argv[%d] : %s", i, file_name_arg[i]);
-	}
+	printf("argc : %d\n", argc);
+	// for(int i = 0; i < argc + 1; i++)
+	// {
+	// 	if(file_name_arg[i] != NULL){
+	// 		printf("argv[%d] : %s\n", i, file_name_arg[i]);
+	// 	}else{
+	// 		printf("argv[%d] : null\n", i);
+	// 	}
+	// }
 	/* Open executable file. */
 	file = filesys_open(program_name);
 	if (file == NULL)
@@ -474,30 +478,40 @@ void copy_to_user_stack(struct intr_frame *_if,char **file_name_arg, uint64_t ar
 	uintptr_t rsp = _if->rsp; //움직일 rsp
 	uintptr_t origin_rsp = _if->rsp; //최초 시작 rsp
 
+	char **arg_addr = (char **)palloc_get_page(0);
+
 	for(int i = argc - 1; i >= 0; i--) {
-		size_t len = strlen(file_name_arg[i]); 
+		size_t len = strlen(file_name_arg[i]) + 1; 
 		rsp = rsp - len;
 		memcpy(rsp, file_name_arg[i], len);
+
+		arg_addr[i] = rsp;
+
+		//rsp = rsp - len;
+		//printf("argv[%d] : %s", i, rsp);
 	}
 
 	if(DIST_RSP(origin_rsp, rsp) % 8 != 0){ // padding 넣어줌
 		rsp -= PADDING(origin_rsp, rsp);
 	}
 
-	rsp -= sizeof(NULL); //NULL 채워주기
+	uint64_t zero = 0;
 
-	memcpy(rsp, NULL, sizeof(NULL)); //포인터들 채워줌
+	rsp -= sizeof(NULL); //NULL 채워주기
+	memcpy(rsp, &zero, sizeof(NULL)); //포인터들 채워줌
 	for(int i = argc - 1; i >= 0; i--) {
 		size_t size = sizeof(file_name_arg[i]);
 		rsp = rsp - size;
-		memcpy(rsp, &file_name_arg[i], size);
+		//memcpy(rsp, &file_name_arg[i], size);
+		memcpy(rsp, &arg_addr[i], size);
+
 		if(i == 0) { //rsi갱신
 			_if->R.rsi = rsp;
 		}
 	}
 
 	rsp -= sizeof(NULL); // NULL 채워주기
-	memcpy(rsp, NULL, sizeof(NULL));
+	memcpy(rsp, &zero, sizeof(NULL));
 
 	_if->rsp = rsp; //rsp 삽입
 	

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -223,6 +223,12 @@ void process_exit(void)
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
 
+	/*
+		프로세스가 종료될 때 출력해야 하는 메시지를 구현해라.
+		process_termination.html 을 참고하라.
+		exit: exit(57) 가 출력되어야 함.
+	*/
+	printf("%s: exit(%d)\n", curr->name, curr->exit_status);
 	process_cleanup();
 }
 
@@ -371,7 +377,6 @@ load(const char *file_name, struct intr_frame *if_)
 		argc++;
 	}
 
-	printf("argc : %d\n", argc);
 	// for(int i = 0; i < argc + 1; i++)
 	// {
 	// 	if(file_name_arg[i] != NULL){

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -165,25 +165,10 @@ error:
 
 /* Switch the current execution context to the f_name.
  * Returns -1 on fail. */
-int process_exec(void *f_name)
-{
-	char *file_name_copy = palloc_get_page(0);
-	char *command_line = f_name;
+int
+process_exec (void *f_name) {
+	char *file_name = f_name;
 	bool success;
-	char **file_name_arg = (char **)palloc_get_page(0);
-	char *save_ptr;
-
-	strlcpy(file_name_copy, f_name, PGSIZE);
-
-	char *program_name = __strtok_r(file_name_copy, " ", &save_ptr);
-	file_name_arg[0] = program_name;
-
-	uint64_t argc = 1;
-	for (char *args = __strtok_r(NULL, " ", &save_ptr); args != NULL; args = __strtok_r(NULL, " ", &save_ptr))
-	{
-		file_name_arg[argc] = args;
-		argc++;
-	}
 
 	/* We cannot use the intr_frame in the thread structure.
 	 * This is because when current thread rescheduled,
@@ -194,19 +179,19 @@ int process_exec(void *f_name)
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
 	/* We first kill the current context */
-	process_cleanup();
+	process_cleanup ();
 
 	/* And then load the binary */
-	success = load(program_name, &_if);
+	success = load (file_name, &_if);
 
 	/* If load failed, quit. */
-	palloc_free_page(program_name);
+	palloc_free_page (file_name);
 	if (!success)
 		return -1;
 
 	/* Start switched process. */
-	do_iret(&_if);
-	NOT_REACHED();
+	do_iret (&_if);
+	NOT_REACHED ();
 }
 
 /* Waits for thread TID to die and returns its exit status.  If
@@ -359,11 +344,32 @@ load(const char *file_name, struct intr_frame *if_)
 		goto done;
 	process_activate(thread_current());
 
+	/*
+	arg를 포함한 file_name을 파싱해서 실제 파일 이름은 program_name에 넣고 args는 file_name_arg 배열에 넣는다.
+	*/
+
+	char *file_name_copy = palloc_get_page(0);
+	char *command_line = file_name;
+	char **file_name_arg = (char **)palloc_get_page(0);
+	char *save_ptr;
+
+	strlcpy(file_name_copy, file_name, PGSIZE);
+
+	char *program_name = __strtok_r(file_name_copy, " ", &save_ptr);
+	file_name_arg[0] = program_name;
+
+	uint64_t argc = 1;
+	for (char *args = __strtok_r(NULL, " ", &save_ptr); args != NULL; args = __strtok_r(NULL, " ", &save_ptr))
+	{
+		file_name_arg[argc] = args;
+		argc++;
+	}
+
 	/* Open executable file. */
-	file = filesys_open(file_name);
+	file = filesys_open(program_name);
 	if (file == NULL)
 	{
-		printf("load: %s: open failed\n", file_name);
+		printf("load: %s: open failed\n", program_name);
 		goto done;
 	}
 
@@ -371,7 +377,7 @@ load(const char *file_name, struct intr_frame *if_)
 	if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr || memcmp(ehdr.e_ident, "\177ELF\2\1\1", 7) || ehdr.e_type != 2 || ehdr.e_machine != 0x3E // amd64
 		|| ehdr.e_version != 1 || ehdr.e_phentsize != sizeof(struct Phdr) || ehdr.e_phnum > 1024)
 	{
-		printf("load: %s: error loading executable\n", file_name);
+		printf("load: %s: error loading executable\n", program_name);
 		goto done;
 	}
 
@@ -442,6 +448,8 @@ load(const char *file_name, struct intr_frame *if_)
 
 	/* TODO: Your code goes here.
 	 * TODO: Implement argument passing (see project2/argument_passing.html). */
+	 copy_to_user_stack(if_, file_name_arg);
+
 
 	success = true;
 
@@ -449,6 +457,10 @@ done:
 	/* We arrive here whether the load is successful or not. */
 	file_close(file);
 	return success;
+}
+
+void copy_to_user_stack(struct intr_frame *_if,char **file_name_arg) {
+	
 }
 
 /* Checks whether PHDR describes a valid, loadable segment in

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -22,15 +22,16 @@
 #include "vm/vm.h"
 #endif
 
-static void process_cleanup (void);
-static bool load (const char *file_name, struct intr_frame *if_);
-static void initd (void *f_name);
-static void __do_fork (void *);
+static void process_cleanup(void);
+static bool load(const char *file_name, struct intr_frame *if_);
+static void initd(void *f_name);
+static void __do_fork(void *);
 
 /* General process initializer for initd and other process. */
 static void
-process_init (void) {
-	struct thread *current = thread_current ();
+process_init(void)
+{
+	struct thread *current = thread_current();
 }
 
 /* Starts the first userland program, called "initd", loaded from FILE_NAME.
@@ -38,55 +39,57 @@ process_init (void) {
  * before process_create_initd() returns. Returns the initd's
  * thread id, or TID_ERROR if the thread cannot be created.
  * Notice that THIS SHOULD BE CALLED ONCE. */
-tid_t
-process_create_initd (const char *file_name) {
+tid_t process_create_initd(const char *file_name)
+{
 	char *fn_copy;
 	tid_t tid;
 
 	/* Make a copy of FILE_NAME.
 	 * Otherwise there's a race between the caller and load(). */
-	fn_copy = palloc_get_page (0);
+	fn_copy = palloc_get_page(0);
 	if (fn_copy == NULL)
 		return TID_ERROR;
-	strlcpy (fn_copy, file_name, PGSIZE);
+	strlcpy(fn_copy, file_name, PGSIZE);
 
 	/* Create a new thread to execute FILE_NAME. */
-	tid = thread_create (file_name, PRI_DEFAULT, initd, fn_copy);
+	tid = thread_create(file_name, PRI_DEFAULT, initd, fn_copy);
 	if (tid == TID_ERROR)
-		palloc_free_page (fn_copy);
+		palloc_free_page(fn_copy);
 	return tid;
 }
 
 /* A thread function that launches first user process. */
 static void
-initd (void *f_name) {
+initd(void *f_name)
+{
 #ifdef VM
-	supplemental_page_table_init (&thread_current ()->spt);
+	supplemental_page_table_init(&thread_current()->spt);
 #endif
 
-	process_init ();
+	process_init();
 
-	if (process_exec (f_name) < 0)
+	if (process_exec(f_name) < 0)
 		PANIC("Fail to launch initd\n");
-	NOT_REACHED ();
+	NOT_REACHED();
 }
 
 /* Clones the current process as `name`. Returns the new process's thread id, or
  * TID_ERROR if the thread cannot be created. */
-tid_t
-process_fork (const char *name, struct intr_frame *if_ UNUSED) {
+tid_t process_fork(const char *name, struct intr_frame *if_ UNUSED)
+{
 	/* Clone current thread to new thread.*/
-	return thread_create (name,
-			PRI_DEFAULT, __do_fork, thread_current ());
+	return thread_create(name,
+						 PRI_DEFAULT, __do_fork, thread_current());
 }
 
 #ifndef VM
 /* Duplicate the parent's address space by passing this function to the
  * pml4_for_each. This is only for the project 2. */
 static bool
-duplicate_pte (uint64_t *pte, void *va, void *aux) {
-	struct thread *current = thread_current ();
-	struct thread *parent = (struct thread *) aux;
+duplicate_pte(uint64_t *pte, void *va, void *aux)
+{
+	struct thread *current = thread_current();
+	struct thread *parent = (struct thread *)aux;
 	void *parent_page;
 	void *newpage;
 	bool writable;
@@ -94,7 +97,7 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 	/* 1. TODO: If the parent_page is kernel page, then return immediately. */
 
 	/* 2. Resolve VA from the parent's page map level 4. */
-	parent_page = pml4_get_page (parent->pml4, va);
+	parent_page = pml4_get_page(parent->pml4, va);
 
 	/* 3. TODO: Allocate new PAL_USER page for the child and set result to
 	 *    TODO: NEWPAGE. */
@@ -105,7 +108,8 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
 
 	/* 5. Add new page to child's page table at address VA with WRITABLE
 	 *    permission. */
-	if (!pml4_set_page (current->pml4, va, newpage, writable)) {
+	if (!pml4_set_page(current->pml4, va, newpage, writable))
+	{
 		/* 6. TODO: if fail to insert page, do error handling. */
 	}
 	return true;
@@ -117,29 +121,30 @@ duplicate_pte (uint64_t *pte, void *va, void *aux) {
  *       That is, you are required to pass second argument of process_fork to
  *       this function. */
 static void
-__do_fork (void *aux) {
+__do_fork(void *aux)
+{
 	struct intr_frame if_;
-	struct thread *parent = (struct thread *) aux;
-	struct thread *current = thread_current ();
+	struct thread *parent = (struct thread *)aux;
+	struct thread *current = thread_current();
 	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
 	struct intr_frame *parent_if;
 	bool succ = true;
 
 	/* 1. Read the cpu context to local stack. */
-	memcpy (&if_, parent_if, sizeof (struct intr_frame));
+	memcpy(&if_, parent_if, sizeof(struct intr_frame));
 
 	/* 2. Duplicate PT */
 	current->pml4 = pml4_create();
 	if (current->pml4 == NULL)
 		goto error;
 
-	process_activate (current);
+	process_activate(current);
 #ifdef VM
-	supplemental_page_table_init (&current->spt);
-	if (!supplemental_page_table_copy (&current->spt, &parent->spt))
+	supplemental_page_table_init(&current->spt);
+	if (!supplemental_page_table_copy(&current->spt, &parent->spt))
 		goto error;
 #else
-	if (!pml4_for_each (parent->pml4, duplicate_pte, parent))
+	if (!pml4_for_each(parent->pml4, duplicate_pte, parent))
 		goto error;
 #endif
 
@@ -149,21 +154,36 @@ __do_fork (void *aux) {
 	 * TODO:       from the fork() until this function successfully duplicates
 	 * TODO:       the resources of parent.*/
 
-	process_init ();
+	process_init();
 
 	/* Finally, switch to the newly created process. */
 	if (succ)
-		do_iret (&if_);
+		do_iret(&if_);
 error:
-	thread_exit ();
+	thread_exit();
 }
 
 /* Switch the current execution context to the f_name.
  * Returns -1 on fail. */
-int
-process_exec (void *f_name) {
-	char *file_name = f_name;
+int process_exec(void *f_name)
+{
+	char *file_name_copy = palloc_get_page(0);
+	char *command_line = f_name;
 	bool success;
+	char **file_name_arg = (char **)palloc_get_page(0);
+	char *save_ptr;
+
+	strlcpy(file_name_copy, f_name, PGSIZE);
+
+	char *program_name = __strtok_r(file_name_copy, " ", &save_ptr);
+	file_name_arg[0] = program_name;
+
+	uint64_t argc = 1;
+	for (char *args = __strtok_r(NULL, " ", &save_ptr); args != NULL; args = __strtok_r(NULL, " ", &save_ptr))
+	{
+		file_name_arg[argc] = args;
+		argc++;
+	}
 
 	/* We cannot use the intr_frame in the thread structure.
 	 * This is because when current thread rescheduled,
@@ -174,21 +194,20 @@ process_exec (void *f_name) {
 	_if.eflags = FLAG_IF | FLAG_MBS;
 
 	/* We first kill the current context */
-	process_cleanup ();
+	process_cleanup();
 
 	/* And then load the binary */
-	success = load (file_name, &_if);
+	success = load(program_name, &_if);
 
 	/* If load failed, quit. */
-	palloc_free_page (file_name);
+	palloc_free_page(program_name);
 	if (!success)
 		return -1;
 
 	/* Start switched process. */
-	do_iret (&_if);
-	NOT_REACHED ();
+	do_iret(&_if);
+	NOT_REACHED();
 }
-
 
 /* Waits for thread TID to die and returns its exit status.  If
  * it was terminated by the kernel (i.e. killed due to an
@@ -199,8 +218,8 @@ process_exec (void *f_name) {
  *
  * This function will be implemented in problem 2-2.  For now, it
  * does nothing. */
-int
-process_wait (tid_t child_tid UNUSED) {
+int process_wait(tid_t child_tid UNUSED)
+{
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
@@ -208,31 +227,33 @@ process_wait (tid_t child_tid UNUSED) {
 }
 
 /* Exit the process. This function is called by thread_exit (). */
-void
-process_exit (void) {
-	struct thread *curr = thread_current ();
+void process_exit(void)
+{
+	struct thread *curr = thread_current();
 	/* TODO: Your code goes here.
 	 * TODO: Implement process termination message (see
 	 * TODO: project2/process_termination.html).
 	 * TODO: We recommend you to implement process resource cleanup here. */
 
-	process_cleanup ();
+	process_cleanup();
 }
 
 /* Free the current process's resources. */
 static void
-process_cleanup (void) {
-	struct thread *curr = thread_current ();
+process_cleanup(void)
+{
+	struct thread *curr = thread_current();
 
 #ifdef VM
-	supplemental_page_table_kill (&curr->spt);
+	supplemental_page_table_kill(&curr->spt);
 #endif
 
 	uint64_t *pml4;
 	/* Destroy the current process's page directory and switch back
 	 * to the kernel-only page directory. */
 	pml4 = curr->pml4;
-	if (pml4 != NULL) {
+	if (pml4 != NULL)
+	{
 		/* Correct ordering here is crucial.  We must set
 		 * cur->pagedir to NULL before switching page directories,
 		 * so that a timer interrupt can't switch back to the
@@ -241,20 +262,20 @@ process_cleanup (void) {
 		 * directory, or our active page directory will be one
 		 * that's been freed (and cleared). */
 		curr->pml4 = NULL;
-		pml4_activate (NULL);
-		pml4_destroy (pml4);
+		pml4_activate(NULL);
+		pml4_destroy(pml4);
 	}
 }
 
 /* Sets up the CPU for running user code in the nest thread.
  * This function is called on every context switch. */
-void
-process_activate (struct thread *next) {
+void process_activate(struct thread *next)
+{
 	/* Activate thread's page tables. */
-	pml4_activate (next->pml4);
+	pml4_activate(next->pml4);
 
 	/* Set thread's kernel stack for use in processing interrupts. */
-	tss_update (next);
+	tss_update(next);
 }
 
 /* We load ELF binaries.  The following definitions are taken
@@ -263,22 +284,23 @@ process_activate (struct thread *next) {
 /* ELF types.  See [ELF1] 1-2. */
 #define EI_NIDENT 16
 
-#define PT_NULL    0            /* Ignore. */
-#define PT_LOAD    1            /* Loadable segment. */
-#define PT_DYNAMIC 2            /* Dynamic linking info. */
-#define PT_INTERP  3            /* Name of dynamic loader. */
-#define PT_NOTE    4            /* Auxiliary info. */
-#define PT_SHLIB   5            /* Reserved. */
-#define PT_PHDR    6            /* Program header table. */
-#define PT_STACK   0x6474e551   /* Stack segment. */
+#define PT_NULL 0			/* Ignore. */
+#define PT_LOAD 1			/* Loadable segment. */
+#define PT_DYNAMIC 2		/* Dynamic linking info. */
+#define PT_INTERP 3			/* Name of dynamic loader. */
+#define PT_NOTE 4			/* Auxiliary info. */
+#define PT_SHLIB 5			/* Reserved. */
+#define PT_PHDR 6			/* Program header table. */
+#define PT_STACK 0x6474e551 /* Stack segment. */
 
-#define PF_X 1          /* Executable. */
-#define PF_W 2          /* Writable. */
-#define PF_R 4          /* Readable. */
+#define PF_X 1 /* Executable. */
+#define PF_W 2 /* Writable. */
+#define PF_R 4 /* Readable. */
 
 /* Executable header.  See [ELF1] 1-4 to 1-8.
  * This appears at the very beginning of an ELF binary. */
-struct ELF64_hdr {
+struct ELF64_hdr
+{
 	unsigned char e_ident[EI_NIDENT];
 	uint16_t e_type;
 	uint16_t e_machine;
@@ -295,7 +317,8 @@ struct ELF64_hdr {
 	uint16_t e_shstrndx;
 };
 
-struct ELF64_PHDR {
+struct ELF64_PHDR
+{
 	uint32_t p_type;
 	uint32_t p_flags;
 	uint64_t p_offset;
@@ -310,19 +333,20 @@ struct ELF64_PHDR {
 #define ELF ELF64_hdr
 #define Phdr ELF64_PHDR
 
-static bool setup_stack (struct intr_frame *if_);
-static bool validate_segment (const struct Phdr *, struct file *);
-static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes,
-		bool writable);
+static bool setup_stack(struct intr_frame *if_);
+static bool validate_segment(const struct Phdr *, struct file *);
+static bool load_segment(struct file *file, off_t ofs, uint8_t *upage,
+						 uint32_t read_bytes, uint32_t zero_bytes,
+						 bool writable);
 
 /* Loads an ELF executable from FILE_NAME into the current thread.
  * Stores the executable's entry point into *RIP
  * and its initial stack pointer into *RSP.
  * Returns true if successful, false otherwise. */
 static bool
-load (const char *file_name, struct intr_frame *if_) {
-	struct thread *t = thread_current ();
+load(const char *file_name, struct intr_frame *if_)
+{
+	struct thread *t = thread_current();
 	struct ELF ehdr;
 	struct file *file = NULL;
 	off_t file_ofs;
@@ -330,85 +354,87 @@ load (const char *file_name, struct intr_frame *if_) {
 	int i;
 
 	/* Allocate and activate page directory. */
-	t->pml4 = pml4_create ();
+	t->pml4 = pml4_create();
 	if (t->pml4 == NULL)
 		goto done;
-	process_activate (thread_current ());
+	process_activate(thread_current());
 
 	/* Open executable file. */
-	file = filesys_open (file_name);
-	if (file == NULL) {
-		printf ("load: %s: open failed\n", file_name);
+	file = filesys_open(file_name);
+	if (file == NULL)
+	{
+		printf("load: %s: open failed\n", file_name);
 		goto done;
 	}
 
 	/* Read and verify executable header. */
-	if (file_read (file, &ehdr, sizeof ehdr) != sizeof ehdr
-			|| memcmp (ehdr.e_ident, "\177ELF\2\1\1", 7)
-			|| ehdr.e_type != 2
-			|| ehdr.e_machine != 0x3E // amd64
-			|| ehdr.e_version != 1
-			|| ehdr.e_phentsize != sizeof (struct Phdr)
-			|| ehdr.e_phnum > 1024) {
-		printf ("load: %s: error loading executable\n", file_name);
+	if (file_read(file, &ehdr, sizeof ehdr) != sizeof ehdr || memcmp(ehdr.e_ident, "\177ELF\2\1\1", 7) || ehdr.e_type != 2 || ehdr.e_machine != 0x3E // amd64
+		|| ehdr.e_version != 1 || ehdr.e_phentsize != sizeof(struct Phdr) || ehdr.e_phnum > 1024)
+	{
+		printf("load: %s: error loading executable\n", file_name);
 		goto done;
 	}
 
 	/* Read program headers. */
 	file_ofs = ehdr.e_phoff;
-	for (i = 0; i < ehdr.e_phnum; i++) {
+	for (i = 0; i < ehdr.e_phnum; i++)
+	{
 		struct Phdr phdr;
 
-		if (file_ofs < 0 || file_ofs > file_length (file))
+		if (file_ofs < 0 || file_ofs > file_length(file))
 			goto done;
-		file_seek (file, file_ofs);
+		file_seek(file, file_ofs);
 
-		if (file_read (file, &phdr, sizeof phdr) != sizeof phdr)
+		if (file_read(file, &phdr, sizeof phdr) != sizeof phdr)
 			goto done;
 		file_ofs += sizeof phdr;
-		switch (phdr.p_type) {
-			case PT_NULL:
-			case PT_NOTE:
-			case PT_PHDR:
-			case PT_STACK:
-			default:
-				/* Ignore this segment. */
-				break;
-			case PT_DYNAMIC:
-			case PT_INTERP:
-			case PT_SHLIB:
-				goto done;
-			case PT_LOAD:
-				if (validate_segment (&phdr, file)) {
-					bool writable = (phdr.p_flags & PF_W) != 0;
-					uint64_t file_page = phdr.p_offset & ~PGMASK;
-					uint64_t mem_page = phdr.p_vaddr & ~PGMASK;
-					uint64_t page_offset = phdr.p_vaddr & PGMASK;
-					uint32_t read_bytes, zero_bytes;
-					if (phdr.p_filesz > 0) {
-						/* Normal segment.
-						 * Read initial part from disk and zero the rest. */
-						read_bytes = page_offset + phdr.p_filesz;
-						zero_bytes = (ROUND_UP (page_offset + phdr.p_memsz, PGSIZE)
-								- read_bytes);
-					} else {
-						/* Entirely zero.
-						 * Don't read anything from disk. */
-						read_bytes = 0;
-						zero_bytes = ROUND_UP (page_offset + phdr.p_memsz, PGSIZE);
-					}
-					if (!load_segment (file, file_page, (void *) mem_page,
-								read_bytes, zero_bytes, writable))
-						goto done;
+		switch (phdr.p_type)
+		{
+		case PT_NULL:
+		case PT_NOTE:
+		case PT_PHDR:
+		case PT_STACK:
+		default:
+			/* Ignore this segment. */
+			break;
+		case PT_DYNAMIC:
+		case PT_INTERP:
+		case PT_SHLIB:
+			goto done;
+		case PT_LOAD:
+			if (validate_segment(&phdr, file))
+			{
+				bool writable = (phdr.p_flags & PF_W) != 0;
+				uint64_t file_page = phdr.p_offset & ~PGMASK;
+				uint64_t mem_page = phdr.p_vaddr & ~PGMASK;
+				uint64_t page_offset = phdr.p_vaddr & PGMASK;
+				uint32_t read_bytes, zero_bytes;
+				if (phdr.p_filesz > 0)
+				{
+					/* Normal segment.
+					 * Read initial part from disk and zero the rest. */
+					read_bytes = page_offset + phdr.p_filesz;
+					zero_bytes = (ROUND_UP(page_offset + phdr.p_memsz, PGSIZE) - read_bytes);
 				}
 				else
+				{
+					/* Entirely zero.
+					 * Don't read anything from disk. */
+					read_bytes = 0;
+					zero_bytes = ROUND_UP(page_offset + phdr.p_memsz, PGSIZE);
+				}
+				if (!load_segment(file, file_page, (void *)mem_page,
+								  read_bytes, zero_bytes, writable))
 					goto done;
-				break;
+			}
+			else
+				goto done;
+			break;
 		}
 	}
 
 	/* Set up stack. */
-	if (!setup_stack (if_))
+	if (!setup_stack(if_))
 		goto done;
 
 	/* Start address. */
@@ -421,21 +447,21 @@ load (const char *file_name, struct intr_frame *if_) {
 
 done:
 	/* We arrive here whether the load is successful or not. */
-	file_close (file);
+	file_close(file);
 	return success;
 }
-
 
 /* Checks whether PHDR describes a valid, loadable segment in
  * FILE and returns true if so, false otherwise. */
 static bool
-validate_segment (const struct Phdr *phdr, struct file *file) {
+validate_segment(const struct Phdr *phdr, struct file *file)
+{
 	/* p_offset and p_vaddr must have the same page offset. */
 	if ((phdr->p_offset & PGMASK) != (phdr->p_vaddr & PGMASK))
 		return false;
 
 	/* p_offset must point within FILE. */
-	if (phdr->p_offset > (uint64_t) file_length (file))
+	if (phdr->p_offset > (uint64_t)file_length(file))
 		return false;
 
 	/* p_memsz must be at least as big as p_filesz. */
@@ -448,9 +474,9 @@ validate_segment (const struct Phdr *phdr, struct file *file) {
 
 	/* The virtual memory region must both start and end within the
 	   user address space range. */
-	if (!is_user_vaddr ((void *) phdr->p_vaddr))
+	if (!is_user_vaddr((void *)phdr->p_vaddr))
 		return false;
-	if (!is_user_vaddr ((void *) (phdr->p_vaddr + phdr->p_memsz)))
+	if (!is_user_vaddr((void *)(phdr->p_vaddr + phdr->p_memsz)))
 		return false;
 
 	/* The region cannot "wrap around" across the kernel virtual
@@ -476,7 +502,7 @@ validate_segment (const struct Phdr *phdr, struct file *file) {
  * outside of #ifndef macro. */
 
 /* load() helpers. */
-static bool install_page (void *upage, void *kpage, bool writable);
+static bool install_page(void *upage, void *kpage, bool writable);
 
 /* Loads a segment starting at offset OFS in FILE at address
  * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
@@ -493,14 +519,16 @@ static bool install_page (void *upage, void *kpage, bool writable);
  * Return true if successful, false if a memory allocation error
  * or disk read error occurs. */
 static bool
-load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
-	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
-	ASSERT (pg_ofs (upage) == 0);
-	ASSERT (ofs % PGSIZE == 0);
+load_segment(struct file *file, off_t ofs, uint8_t *upage,
+			 uint32_t read_bytes, uint32_t zero_bytes, bool writable)
+{
+	ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+	ASSERT(pg_ofs(upage) == 0);
+	ASSERT(ofs % PGSIZE == 0);
 
-	file_seek (file, ofs);
-	while (read_bytes > 0 || zero_bytes > 0) {
+	file_seek(file, ofs);
+	while (read_bytes > 0 || zero_bytes > 0)
+	{
 		/* Do calculate how to fill this page.
 		 * We will read PAGE_READ_BYTES bytes from FILE
 		 * and zero the final PAGE_ZERO_BYTES bytes. */
@@ -508,21 +536,23 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
 		/* Get a page of memory. */
-		uint8_t *kpage = palloc_get_page (PAL_USER);
+		uint8_t *kpage = palloc_get_page(PAL_USER);
 		if (kpage == NULL)
 			return false;
 
 		/* Load this page. */
-		if (file_read (file, kpage, page_read_bytes) != (int) page_read_bytes) {
-			palloc_free_page (kpage);
+		if (file_read(file, kpage, page_read_bytes) != (int)page_read_bytes)
+		{
+			palloc_free_page(kpage);
 			return false;
 		}
-		memset (kpage + page_read_bytes, 0, page_zero_bytes);
+		memset(kpage + page_read_bytes, 0, page_zero_bytes);
 
 		/* Add the page to the process's address space. */
-		if (!install_page (upage, kpage, writable)) {
+		if (!install_page(upage, kpage, writable))
+		{
 			printf("fail\n");
-			palloc_free_page (kpage);
+			palloc_free_page(kpage);
 			return false;
 		}
 
@@ -536,17 +566,19 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 
 /* Create a minimal stack by mapping a zeroed page at the USER_STACK */
 static bool
-setup_stack (struct intr_frame *if_) {
+setup_stack(struct intr_frame *if_)
+{
 	uint8_t *kpage;
 	bool success = false;
 
-	kpage = palloc_get_page (PAL_USER | PAL_ZERO);
-	if (kpage != NULL) {
-		success = install_page (((uint8_t *) USER_STACK) - PGSIZE, kpage, true);
+	kpage = palloc_get_page(PAL_USER | PAL_ZERO);
+	if (kpage != NULL)
+	{
+		success = install_page(((uint8_t *)USER_STACK) - PGSIZE, kpage, true);
 		if (success)
 			if_->rsp = USER_STACK;
 		else
-			palloc_free_page (kpage);
+			palloc_free_page(kpage);
 	}
 	return success;
 }
@@ -561,13 +593,13 @@ setup_stack (struct intr_frame *if_) {
  * Returns true on success, false if UPAGE is already mapped or
  * if memory allocation fails. */
 static bool
-install_page (void *upage, void *kpage, bool writable) {
-	struct thread *t = thread_current ();
+install_page(void *upage, void *kpage, bool writable)
+{
+	struct thread *t = thread_current();
 
 	/* Verify that there's not already a page at that virtual
 	 * address, then map our page there. */
-	return (pml4_get_page (t->pml4, upage) == NULL
-			&& pml4_set_page (t->pml4, upage, kpage, writable));
+	return (pml4_get_page(t->pml4, upage) == NULL && pml4_set_page(t->pml4, upage, kpage, writable));
 }
 #else
 /* From here, codes will be used after project 3.
@@ -575,7 +607,8 @@ install_page (void *upage, void *kpage, bool writable) {
  * upper block. */
 
 static bool
-lazy_load_segment (struct page *page, void *aux) {
+lazy_load_segment(struct page *page, void *aux)
+{
 	/* TODO: Load the segment from the file */
 	/* TODO: This called when the first page fault occurs on address VA. */
 	/* TODO: VA is available when calling this function. */
@@ -596,13 +629,15 @@ lazy_load_segment (struct page *page, void *aux) {
  * Return true if successful, false if a memory allocation error
  * or disk read error occurs. */
 static bool
-load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
-	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
-	ASSERT (pg_ofs (upage) == 0);
-	ASSERT (ofs % PGSIZE == 0);
+load_segment(struct file *file, off_t ofs, uint8_t *upage,
+			 uint32_t read_bytes, uint32_t zero_bytes, bool writable)
+{
+	ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+	ASSERT(pg_ofs(upage) == 0);
+	ASSERT(ofs % PGSIZE == 0);
 
-	while (read_bytes > 0 || zero_bytes > 0) {
+	while (read_bytes > 0 || zero_bytes > 0)
+	{
 		/* Do calculate how to fill this page.
 		 * We will read PAGE_READ_BYTES bytes from FILE
 		 * and zero the final PAGE_ZERO_BYTES bytes. */
@@ -611,8 +646,8 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 
 		/* TODO: Set up aux to pass information to the lazy_load_segment. */
 		void *aux = NULL;
-		if (!vm_alloc_page_with_initializer (VM_ANON, upage,
-					writable, lazy_load_segment, aux))
+		if (!vm_alloc_page_with_initializer(VM_ANON, upage,
+											writable, lazy_load_segment, aux))
 			return false;
 
 		/* Advance. */
@@ -625,9 +660,10 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 
 /* Create a PAGE of stack at the USER_STACK. Return true on success. */
 static bool
-setup_stack (struct intr_frame *if_) {
+setup_stack(struct intr_frame *if_)
+{
 	bool success = false;
-	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
+	void *stack_bottom = (void *)(((uint8_t *)USER_STACK) - PGSIZE);
 
 	/* TODO: Map the stack on stack_bottom and claim the page immediately.
 	 * TODO: If success, set the rsp accordingly.

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -208,6 +208,9 @@ int process_wait(tid_t child_tid UNUSED)
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
+	while(true){
+		thread_yield();
+	}
 	return -1;
 }
 
@@ -282,6 +285,9 @@ void process_activate(struct thread *next)
 #define PF_W 2 /* Writable. */
 #define PF_R 4 /* Readable. */
 
+#define DIST_RSP(origin_rsp, rsp) ((origin_rsp) - (rsp))
+#define PADDING(origin_rsp, rsp) ((((DIST_RSP(origin_rsp, rsp)) / 8) + 1) * 8) - (DIST_RSP(origin_rsp, rsp))
+
 /* Executable header.  See [ELF1] 1-4 to 1-8.
  * This appears at the very beginning of an ELF binary. */
 struct ELF64_hdr
@@ -348,23 +354,28 @@ load(const char *file_name, struct intr_frame *if_)
 	arg를 포함한 file_name을 파싱해서 실제 파일 이름은 program_name에 넣고 args는 file_name_arg 배열에 넣는다.
 	*/
 
-	char *file_name_copy = palloc_get_page(0);
+	char *file_name_copy = (char *) palloc_get_page(0);
 	char *command_line = file_name;
 	char **file_name_arg = (char **)palloc_get_page(0);
 	char *save_ptr;
 
 	strlcpy(file_name_copy, file_name, PGSIZE);
 
-	char *program_name = __strtok_r(file_name_copy, " ", &save_ptr);
+	char *program_name = strtok_r(file_name_copy, " ", &save_ptr);
 	file_name_arg[0] = program_name;
 
 	uint64_t argc = 1;
-	for (char *args = __strtok_r(NULL, " ", &save_ptr); args != NULL; args = __strtok_r(NULL, " ", &save_ptr))
+	for (char *args = strtok_r(NULL, " ", &save_ptr); args != NULL; args = strtok_r(NULL, " ", &save_ptr))
 	{
 		file_name_arg[argc] = args;
 		argc++;
 	}
 
+	printf("나여: argc. %d\n", argc);
+	for(int i = 0; i < argc; i++)
+	{
+		printf("나여 argv[%d] : %s", i, file_name_arg[i]);
+	}
 	/* Open executable file. */
 	file = filesys_open(program_name);
 	if (file == NULL)
@@ -448,8 +459,8 @@ load(const char *file_name, struct intr_frame *if_)
 
 	/* TODO: Your code goes here.
 	 * TODO: Implement argument passing (see project2/argument_passing.html). */
-	 copy_to_user_stack(if_, file_name_arg);
-
+	 copy_to_user_stack(if_, file_name_arg, argc);
+	 if_->R.rdi = argc; //rdi에 카운트 채워주기
 
 	success = true;
 
@@ -459,7 +470,36 @@ done:
 	return success;
 }
 
-void copy_to_user_stack(struct intr_frame *_if,char **file_name_arg) {
+void copy_to_user_stack(struct intr_frame *_if,char **file_name_arg, uint64_t argc) {
+	uintptr_t rsp = _if->rsp; //움직일 rsp
+	uintptr_t origin_rsp = _if->rsp; //최초 시작 rsp
+
+	for(int i = argc - 1; i >= 0; i--) {
+		size_t len = strlen(file_name_arg[i]); 
+		rsp = rsp - len;
+		memcpy(rsp, file_name_arg[i], len);
+	}
+
+	if(DIST_RSP(origin_rsp, rsp) % 8 != 0){ // padding 넣어줌
+		rsp -= PADDING(origin_rsp, rsp);
+	}
+
+	rsp -= sizeof(NULL); //NULL 채워주기
+
+	memcpy(rsp, NULL, sizeof(NULL)); //포인터들 채워줌
+	for(int i = argc - 1; i >= 0; i--) {
+		size_t size = sizeof(file_name_arg[i]);
+		rsp = rsp - size;
+		memcpy(rsp, &file_name_arg[i], size);
+		if(i == 0) { //rsi갱신
+			_if->R.rsi = rsp;
+		}
+	}
+
+	rsp -= sizeof(NULL); // NULL 채워주기
+	memcpy(rsp, NULL, sizeof(NULL));
+
+	_if->rsp = rsp; //rsp 삽입
 	
 }
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -8,6 +8,7 @@
 #include "threads/flags.h"
 #include "intrinsic.h"
 #include "kernel/stdio.h"
+#include "threads/init.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -45,10 +46,22 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	uint64_t sys_type = f->R.rax; 
 
 	switch(sys_type){
-		case SYS_HALT:
+		/*
+			Pintos를 종료하는 syscall
+			power_off() 를 호출하면 됨.
+		*/
+		case SYS_HALT: 
+			power_off();
 			break;
-
+		/*
+			현재 user program을 종료하고, 종료 상태 값을 커널에 남긴다.
+			부모가 wait 하면 이 status 값을 받아야 한다. 
+			관례적으로 0 = 성공, 0 이 아닌 값 = 실패
+		*/
 		case SYS_EXIT:
+			struct thread *curr = thread_current();
+			curr->exit_status = f->R.rdi;
+			thread_exit();
 			break;
 
 		case SYS_FORK:
@@ -101,5 +114,5 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	}
 
 	printf("system call!\n");
-	thread_exit();
+	//thread_exit();
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -53,7 +53,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 				putbuf(buf, (size_t)size);
 
 				f->R.rax = size; //rax갱신 
-				break;
+				return;
 			}	
 	}
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -45,6 +45,36 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	uint64_t sys_type = f->R.rax; 
 
 	switch(sys_type){
+		case SYS_HALT:
+			break;
+
+		case SYS_EXIT:
+			break;
+
+		case SYS_FORK:
+			break;
+
+		case SYS_EXEC:
+			break;
+
+		case SYS_WAIT:
+			break;
+
+		case SYS_CREATE:
+			break;
+
+		case SYS_REMOVE:
+			break;
+
+		case SYS_OPEN:
+			break;
+
+		case SYS_FILESIZE:
+			break;
+
+		case SYS_READ:
+			break;
+
 		case SYS_WRITE:
 			if(f->R.rdi == 1) {
 				//rsi -> buf, rdx -> size
@@ -54,7 +84,20 @@ syscall_handler (struct intr_frame *f UNUSED) {
 
 				f->R.rax = size; //rax갱신 
 				return;
-			}	
+			}
+			break;
+
+		case SYS_SEEK:
+			break;
+
+		case SYS_TELL:
+			break;
+
+		case SYS_CLOSE:
+			break;
+			
+		default:
+			break;
 	}
 
 	printf("system call!\n");

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -7,6 +7,7 @@
 #include "userprog/gdt.h"
 #include "threads/flags.h"
 #include "intrinsic.h"
+#include "kernel/stdio.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -41,6 +42,21 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f UNUSED) {
 	// TODO: Your implementation goes here.
-	printf ("system call!\n");
-	thread_exit ();
+	uint64_t sys_type = f->R.rax; 
+
+	switch(sys_type){
+		case SYS_WRITE:
+			if(f->R.rdi == 1) {
+				//rsi -> buf, rdx -> size
+				uint64_t buf = f->R.rsi;
+				uint64_t size = f->R.rdx;
+				putbuf(buf, (size_t)size);
+
+				f->R.rax = size; //rax갱신 
+				break;
+			}	
+	}
+
+	printf("system call!\n");
+	thread_exit();
 }


### PR DESCRIPTION
﻿## 요약
`sys_halt`와 `sys_exit` 시스템 콜 동작을 구현했습니다.

## 변경 사항
- 시스템 종료 요청을 처리하는 `sys_halt` 경로를 연결했습니다.
- 프로세스 종료 요청을 처리하는 `sys_exit` 경로를 구현했습니다.
- 종료 코드 및 종료 흐름이 일관되게 이어지도록 관련 처리 지점을 정리했습니다.

## 테스트
- 별도 테스트는 아직 수행하지 않았습니다.

## 비고
`feat-#22`가 `feat-#19`에서 분기되었기 때문에, `dev` 기준 PR에는 해당 선행 변경도 함께 포함됩니다.

Closes #22
