### PR TITLE
feat: file syscall read write 및 create remove 처리 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,7 +5,6 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
-#include "filesys/file.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "filesys/file.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -127,6 +128,11 @@ struct thread
 	*/
 	int nice; // 해당 thread가 양보적인지 나타내는 수치
 	fixed_t recent_cpu; // 해당 thread가 최근에 사용한 cpu time에 대한 수치를 나타내는 변수
+	
+	//File Descriptor
+	struct file * fdt[128]; //각 파일을 가리키는 인덱스 128짜리 fdt테이블 생성
+	int next_fd;
+
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -107,8 +107,8 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			break;
 
 		case SYS_CREATE:{
-			const char *file = f->R.rdi;
-			unsigned initial_size = f->R.rsi;
+			const char *file = (const char*)f->R.rdi;
+			unsigned initial_size = (unsigned)f->R.rsi;
 
 			check_valid_addr(file);
 
@@ -138,7 +138,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_READ:{
 			int fd = f->R.rdi;
 			char *buffer = (char *)f->R.rsi;
-			unsigned size = f->R.rdx; 
+			unsigned size = (unsigned)f->R.rdx; 
 
 			check_valid_pointer(buffer, size - 1);
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -17,6 +17,7 @@ void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 void check_valid_addr(void *addr);
 void check_valid_pointer(void *start, size_t size);
+void check_valid_str(char *str);
 
 // 껍데기
 int process_add_file(struct file *file); //새로 열린 파일을 fd table에 등록하고 fd번호 리턴
@@ -70,6 +71,14 @@ void check_valid_pointer(void *start, size_t size){
 	}
 }
 
+void check_valid_str(char *str){
+	for(int i = 0;; i++){
+		if(str[i] == '\0'){
+			break;
+		}
+		check_valid_addr(&str[i]);
+	}
+}
 
 /* The main system call interface */
 void
@@ -107,18 +116,19 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			break;
 
 		case SYS_CREATE:{
+			// file 이름 문자열의 주소를 검사?
 			const char *file = (const char*)f->R.rdi;
 			unsigned initial_size = (unsigned)f->R.rsi;
-
-			check_valid_addr(file);
-
+			
+			check_valid_str(file);
+			
 			f->R.rax = filesys_create(file, initial_size);
 			return;
 		}
 		case SYS_REMOVE:{
 			const char *file = f->R.rdi;
 
-			check_valid_addr(file);
+			check_valid_str(file);
 
 			f->R.rax = filesys_remove(file);
 			return;
@@ -128,7 +138,11 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			break;
 
 		case SYS_FILESIZE:{
-			break;
+			// file.c 에 file_length(file *)
+			// file 안에 있는 바이트 개수를 반환하는 함수 사용
+			int fd = f->R.rdi;
+
+			return;
 		}
 		/*
 			read(fd, buffer, size)
@@ -140,6 +154,10 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			char *buffer = (char *)f->R.rsi;
 			unsigned size = (unsigned)f->R.rdx; 
 
+			if(size == 0){
+				f->R.rax = 0;
+				return;
+			}
 			check_valid_pointer(buffer, size - 1);
 
 			if(fd == 1){
@@ -187,6 +205,11 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			int fd = f->R.rdi;
 			void *buffer = f->R.rsi;
 			unsigned size = f->R.rdx;
+
+			if(size == 0){
+				f->R.rax = 0;
+				return;
+			}
 
 			check_valid_pointer(buffer, size - 1);
 

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -127,9 +127,9 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_OPEN:
 			break;
 
-		case SYS_FILESIZE:
+		case SYS_FILESIZE:{
 			break;
-
+		}
 		/*
 			read(fd, buffer, size)
 			fd -> buffer
@@ -162,21 +162,21 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			// 해당 파일에서 데이터를 읽고 buffer 에 저장한다.
 			// OPEN SYSCALL 필요?
 
-			// else if(fd > 1){
-			// 	// 일단 구현되어 있다고 하고 사용했음. 
-			// 	// 주석에 따르면 fd번호로 실제 파일 객체를 찾음 
-			// 	// 아직 테스트를 못돌림. process_get_file() 이 구현이 안되어 있음.
-			// 	struct file *file = process_get_file(fd);
-			// 	// 해당 fd를 찾아서 fd 테이블에 가서 파일을 찾았는데 없는 경우가 있을 수도 있음.
-			// 	if(file == NULL){
-			// 		f->R.rax = -1;
-    		// 		return;
-			// 	}
-			// 	off_t real_size = file_read(file, buffer, size);
+			else if(fd > 1){
+				// 일단 구현되어 있다고 하고 사용했음. 
+				// 주석에 따르면 fd번호로 실제 파일 객체를 찾음 
+				// 아직 테스트를 못돌림. process_get_file() 이 구현이 안되어 있음.
+				struct file *file = process_get_file(fd);
+				// 해당 fd를 찾아서 fd 테이블에 가서 파일을 찾았는데 없는 경우가 있을 수도 있음.
+				if(file == NULL){
+					f->R.rax = -1;
+    				return;
+				}
+				off_t real_size = file_read(file, buffer, size);
 				
-			// 	f->R.rax = real_size;
-			// 	return;
-			// }
+				f->R.rax = real_size;
+				return;
+			}
 
 			// 잘못된 fd 입력값
 			f->R.rax = -1;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -83,19 +83,20 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			Pintos를 종료하는 syscall
 			power_off() 를 호출하면 됨.
 		*/
-		case SYS_HALT: 
+		case SYS_HALT:{
 			power_off();
 			break;
+		}
 		/*
 			현재 user program을 종료하고, 종료 상태 값을 커널에 남긴다.
 			부모가 wait 하면 이 status 값을 받아야 한다. 
 			관례적으로 0 = 성공, 0 이 아닌 값 = 실패
 		*/
-		case SYS_EXIT:
+		case SYS_EXIT:{
 			curr->exit_status = f->R.rdi;
 			thread_exit();
 			break;
-
+		}
 		case SYS_FORK:
 			break;
 
@@ -161,22 +162,22 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			// 해당 파일에서 데이터를 읽고 buffer 에 저장한다.
 			// OPEN SYSCALL 필요?
 
-			else if(fd > 1){
-				// 일단 구현되어 있다고 하고 사용했음. 
-				// 주석에 따르면 fd번호로 실제 파일 객체를 찾음 
-				// 아직 테스트를 못돌림. process_get_file() 이 구현이 안되어 있음.
-				struct file *file = process_get_file(fd);
-				// 해당 fd를 찾아서 fd 테이블에 가서 파일을 찾았는데 없는 경우가 있을 수도 있음.
-				if(file == NULL){
-					f->R.rax = -1;
-    				return;
-				}
-				off_t real_size;
-				real_size = file_read(file, buffer, size);
+			// else if(fd > 1){
+			// 	// 일단 구현되어 있다고 하고 사용했음. 
+			// 	// 주석에 따르면 fd번호로 실제 파일 객체를 찾음 
+			// 	// 아직 테스트를 못돌림. process_get_file() 이 구현이 안되어 있음.
+			// 	struct file *file = process_get_file(fd);
+			// 	// 해당 fd를 찾아서 fd 테이블에 가서 파일을 찾았는데 없는 경우가 있을 수도 있음.
+			// 	if(file == NULL){
+			// 		f->R.rax = -1;
+    		// 		return;
+			// 	}
+			// 	off_t real_size = file_read(file, buffer, size);
 				
-				f->R.rax = real_size;
-				return;
-			}
+			// 	f->R.rax = real_size;
+			// 	return;
+			// }
+
 			// 잘못된 fd 입력값
 			f->R.rax = -1;
 			return;
@@ -189,13 +190,32 @@ syscall_handler (struct intr_frame *f UNUSED) {
 
 			check_valid_pointer(buffer, size - 1);
 
-			if(fd == 1) {
-				putbuf(buffer, (size_t)size);
-
-				f->R.rax = size; //rax갱신 
+			if(fd == 0){
+				f->R.rax = -1;
 				return;
 			}
-			break;
+			else if(fd == 1) {
+				putbuf(buffer, (size_t)size);
+
+				f->R.rax = size;
+				return;
+			}
+			else if(fd > 1){
+				// fd가 1 이상이라면 해당 fd에 맞는 열려 있는 파일을 찾고
+				// buffer 에 있는걸 읽고, 그 파일에 쓴다.
+				// 쓴 byte 수(size)를 rax에 반환.
+				struct file *file = process_get_file(fd);
+				if(file == NULL){
+					f->R.rax = -1;
+					return;
+				}
+				off_t real_size = file_write(file, buffer, size);
+				
+				f->R.rax = real_size;
+				return;
+			}
+			f->R.rax = -1;
+			return;
 		}
 		case SYS_SEEK:
 			break;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -77,6 +77,15 @@ void check_valid_pointer(void *start, size_t size){
 	}
 }
 
+void check_valid_str(char *str){
+	for(int i = 0;; i++){
+		if(str[i] == '\0'){
+			break;
+		}
+		check_valid_addr(&str[i]);
+	}
+}
+
 int process_add_file(struct file *file) // 새로 열린 파일을 fd table에 등록하고 fd번호 리턴. 실패시 -1 리턴
 {
 	if(file == NULL) { return -1; } //잘못된 파일 들어오면

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -9,6 +9,7 @@
 #include "intrinsic.h"
 #include "kernel/stdio.h"
 #include "threads/init.h"
+#include "filesys/filesys.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
@@ -97,7 +98,13 @@ syscall_handler (struct intr_frame *f UNUSED) {
 			break;
 
 		case SYS_CREATE:
-			break;
+			char *name = f->R.rdi;
+			int initial_size = f->R.rsi;
+
+			check_valid_addr(name);
+			
+			f->R.rax = filesys_create(name, initial_size);
+			return;
 
 		case SYS_REMOVE:
 			break;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -10,11 +10,19 @@
 #include "kernel/stdio.h"
 #include "threads/init.h"
 #include "filesys/filesys.h"
+#include "devices/input.h"
+#include "filesys/file.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 void check_valid_addr(void *addr);
 void check_valid_pointer(void *start, size_t size);
+
+// 껍데기
+int process_add_file(struct file *file); //새로 열린 파일을 fd table에 등록하고 fd번호 리턴
+struct file *process_get_file(int fd); //fd번호로 실제 파일 객체를 찾음
+void process_close_file(int fd); //fd 하나를 닫음
+void process_close_all_files(void); //현재 프로세스가 열어둔 모든 파일을 닫음
 
 /* System call.
  *
@@ -121,18 +129,68 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_FILESIZE:
 			break;
 
-		case SYS_READ:
-			break;
+		/*
+			read(fd, buffer, size)
+			fd -> buffer
+			fd에서 읽고, buffer에 씀
+		*/
+		case SYS_READ:{
+			int fd = f->R.rdi;
+			char *buffer = (char *)f->R.rsi;
+			unsigned size = f->R.rdx; 
+
+			check_valid_pointer(buffer, size - 1);
+
+			if(fd == 1){
+				f->R.rax = -1;
+				return;
+			}
+			else if(fd == 0){
+				// input_getc() => 사용자로부터 한글자를 입력받음
+				// 한 글자씩 받아서 size 만큼 반복하면서 buffer에 채워넣음.
+				for(int i = 0; i < size; i++){
+					buffer[i] = input_getc();
+				}
+				// 실제 읽은 바이트 수를 반환해야 하는데?
+				// 그냥 size를 rax에 넣으면 안될거같은데
+				// 사용자 입력값은 중간에 NULL 을 입력해도 끝까지 입력하니까 상관없다?
+				f->R.rax = size;
+				return;
+			}
+			// fd가 1보다 크면, 해당 fd에 적혀있는 번호에 맞는 파일을 열어야 함 X => 해당하는 열린 파일을 찾는다?
+			// 해당 파일에서 데이터를 읽고 buffer 에 저장한다.
+			// OPEN SYSCALL 필요?
+
+			else if(fd > 1){
+				// 일단 구현되어 있다고 하고 사용했음. 
+				// 주석에 따르면 fd번호로 실제 파일 객체를 찾음 
+				// 아직 테스트를 못돌림. process_get_file() 이 구현이 안되어 있음.
+				struct file *file = process_get_file(fd);
+				// 해당 fd를 찾아서 fd 테이블에 가서 파일을 찾았는데 없는 경우가 있을 수도 있음.
+				if(file == NULL){
+					f->R.rax = -1;
+    				return;
+				}
+				off_t real_size;
+				real_size = file_read(file, buffer, size);
+				
+				f->R.rax = real_size;
+				return;
+			}
+			// 잘못된 fd 입력값
+			f->R.rax = -1;
+			return;
+		}
 
 		case SYS_WRITE:{
-			uint64_t buf = f->R.rsi;
-			uint64_t size = f->R.rdx;
+			int fd = f->R.rdi;
+			void *buffer = f->R.rsi;
+			unsigned size = f->R.rdx;
 
-			check_valid_pointer(buf, size - 1);
+			check_valid_pointer(buffer, size - 1);
 
-			if(f->R.rdi == 1) {
-				//rsi -> buf, rdx -> size
-				putbuf(buf, (size_t)size);
+			if(fd == 1) {
+				putbuf(buffer, (size_t)size);
 
 				f->R.rax = size; //rax갱신 
 				return;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -97,17 +97,23 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_WAIT:
 			break;
 
-		case SYS_CREATE:
-			char *name = f->R.rdi;
-			int initial_size = f->R.rsi;
+		case SYS_CREATE:{
+			const char *file = f->R.rdi;
+			unsigned initial_size = f->R.rsi;
 
-			check_valid_addr(name);
-			
-			f->R.rax = filesys_create(name, initial_size);
+			check_valid_addr(file);
+
+			f->R.rax = filesys_create(file, initial_size);
 			return;
+		}
+		case SYS_REMOVE:{
+			const char *file = f->R.rdi;
 
-		case SYS_REMOVE:
-			break;
+			check_valid_addr(file);
+
+			f->R.rax = filesys_remove(file);
+			return;
+		}
 
 		case SYS_OPEN:
 			break;
@@ -118,7 +124,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		case SYS_READ:
 			break;
 
-		case SYS_WRITE:
+		case SYS_WRITE:{
 			uint64_t buf = f->R.rsi;
 			uint64_t size = f->R.rdx;
 
@@ -132,7 +138,7 @@ syscall_handler (struct intr_frame *f UNUSED) {
 				return;
 			}
 			break;
-
+		}
 		case SYS_SEEK:
 			break;
 


### PR DESCRIPTION
## 요약
`read`, `write`, `create`, `remove` 관련 file syscall 동작을 구현했습니다.

## 변경 사항
- `read` 동작 정의 및 처리를 반영했습니다.
- `write` 동작 정의 및 처리를 반영했습니다.
- `create`, `remove` 동작 정의 및 처리를 반영했습니다.

## 테스트
- 별도 테스트 내역은 PR 본문에 추가로 정리하지 않았습니다.

## 비고
- 위 시스템콜 동작을 안정적으로 처리하기 위한 공통 보조 로직이 함께 포함되어 있습니다.

Closes #27
