### PR TITLE
feat: seek()와 tell() 파일 오프셋 제어 동작 구현

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -130,9 +130,7 @@ struct thread
 	fixed_t recent_cpu; // 해당 thread가 최근에 사용한 cpu time에 대한 수치를 나타내는 변수
 	
 	//File Descriptor
-	struct file * fdt[128]; //각 파일을 가리키는 인덱스 128짜리 fdt테이블 생성
 	int next_fd;
-
 
 	//File Descriptor
 	struct file * fdt[fdt_size]; //각 파일을 가리키는 인덱스 128짜리 fdt테이블 생성

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -159,11 +159,7 @@ void syscall_handler(struct intr_frame *f UNUSED)
 			현재 프로세스를 유지 한 채, 현재 프로세스의 메모리 공간을 새 프로그램으로 갈아 끼운다.
 		*/
 		case SYS_EXEC:{
-			const char *cmd_line = (const char *)f->R.rdi; // cmd_line 받아옴
-			
-			
-			
-			return;
+			break;
 		}
 
 		case SYS_WAIT:

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -12,18 +12,13 @@
 #include "filesys/filesys.h"
 #include "devices/input.h"
 #include "filesys/file.h"
+#include "userprog/process.h"
 
 void syscall_entry (void);
 void syscall_handler (struct intr_frame *);
 void check_valid_addr(void *addr);
 void check_valid_pointer(void *start, size_t size);
 void check_valid_str(char *str);
-
-// 껍데기
-int process_add_file(struct file *file); //새로 열린 파일을 fd table에 등록하고 fd번호 리턴
-struct file *process_get_file(int fd); //fd번호로 실제 파일 객체를 찾음
-void process_close_file(int fd); //fd 하나를 닫음
-void process_close_all_files(void); //현재 프로세스가 열어둔 모든 파일을 닫음
 
 // 껍데기
 int process_add_file(struct file *file); //새로 열린 파일을 fd table에 등록하고 fd번호 리턴
@@ -154,11 +149,22 @@ void syscall_handler(struct intr_frame *f UNUSED)
 			thread_exit();
 			break;
 		}
+
 		case SYS_FORK:
 			break;
 
-		case SYS_EXEC:
-			break;
+		/*
+			현재 프로세스를 지정된 이름의 실행 파일로 변경합니다
+			새 프로세스를 만드는 것이 아니다.
+			현재 프로세스를 유지 한 채, 현재 프로세스의 메모리 공간을 새 프로그램으로 갈아 끼운다.
+		*/
+		case SYS_EXEC:{
+			const char *cmd_line = (const char *)f->R.rdi; // cmd_line 받아옴
+			
+			
+			
+			return;
+		}
 
 		case SYS_WAIT:
 			break;

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -190,6 +190,19 @@ void syscall_handler(struct intr_frame *f UNUSED)
 			// file 안에 있는 바이트 개수를 반환하는 함수 사용
 			int fd = f->R.rdi;
 
+			if(fd < 2){
+				f->R.rax = -1;
+				return;
+			}
+
+			struct file *file = process_get_file(fd);
+
+			if(file == NULL){
+				f->R.rax = -1;
+    			return;
+			}
+			
+			f->R.rax = file_length(file);
 			return;
 		}
 		/*
@@ -288,11 +301,49 @@ void syscall_handler(struct intr_frame *f UNUSED)
 			f->R.rax = -1;
 			return;
 		}
-		case SYS_SEEK:
-			break;
+		/*
+			fd로 열린 파일의 위치를 position 바이트 지점으로 이동한다
+		*/
+		case SYS_SEEK:{
+			int fd = f->R.rdi;
+			unsigned position = (unsigned)f->R.rsi;
 
-		case SYS_TELL:
-			break;
+			if(fd < 2){
+				return;
+			}
+
+			struct file *file = process_get_file(fd);
+			
+			if(file == NULL){
+				return;
+			}
+			// 반환값이 없으면 rax에다가 집어넣을 필요가 없을까
+			// seek() 가 바꾸는건 fd가 가리키는 열린 파일의 현재 offset 위치를 바꾼다.
+			file_seek(file, (off_t)position);
+			return;
+		}
+		/*
+			열려 있는 파일에서 읽거나 쓸 다음 바이트의 위치를 fd​​파일 시작 부분부터 바이트 단위로 반환.
+		*/
+		case SYS_TELL:{
+			int fd = f->R.rdi;
+			
+			if(fd < 2){
+				f->R.rax = -1;
+				return;
+			}
+
+			struct file *file = process_get_file(fd);
+
+			if(file == NULL){
+				f->R.rax = -1;
+				return;
+			}
+
+			f->R.rax = file_tell(file);
+			return;
+		}
+			
 
 		case SYS_CLOSE:
 			break;


### PR DESCRIPTION
﻿## 요약
파일 관련 시스템콜 흐름을 정리하고 `seek()` 및 `tell()` 동작을 추가했습니다.

## 변경 사항
- 파일 오프셋 이동과 현재 위치 조회가 기대한 규칙에 맞게 동작하도록 정리했습니다.
- 파일 관련 시스템콜 경로에서 공통 검증과 예외 처리 흐름을 함께 보완했습니다.
- 기존 파일 디스크립터 기반 처리와 충돌하지 않도록 관련 동작을 맞췄습니다.

## 테스트
- 별도 테스트 수행 여부는 확인하지 못했습니다.

## 비고
- PR 범위는 이슈 #27 기준으로 정리했습니다.

Closes #27
