### PR TITLE
feat: open/close 시스템콜 구현

### DIFF
--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -161,7 +161,7 @@ void syscall_handler(struct intr_frame *f UNUSED)
 			break;
 
 		case SYS_WAIT:
-			
+			break;
 
 		case SYS_CREATE:{
 			// file 이름 문자열의 주소를 검사?
@@ -182,9 +182,8 @@ void syscall_handler(struct intr_frame *f UNUSED)
 			return;
 		}
 
-		case SYS_OPEN:
+		case SYS_OPEN:{
 			uint64_t user_file = f->R.rdi;
-			check_valid_pointer(user_file, sizeof(user_file));
 			check_valid_str(user_file);
 			// 파일 이름을 받아 파일 시스템에서 해당 파일을 찾고, 열린 파일 객체를 만들어 리턴하는 함수
 			struct file * kernel_file = filesys_open(user_file); 
@@ -203,6 +202,7 @@ void syscall_handler(struct intr_frame *f UNUSED)
 				f->R.rax = fdt_number;
 			}
 			return;
+		}
 		case SYS_FILESIZE:{
 			// file.c 에 file_length(file *)
 			// file 안에 있는 바이트 개수를 반환하는 함수 사용

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -161,7 +161,7 @@ void syscall_handler(struct intr_frame *f UNUSED)
 			break;
 
 		case SYS_WAIT:
-			break;
+			
 
 		case SYS_CREATE:{
 			// file 이름 문자열의 주소를 검사?
@@ -183,8 +183,26 @@ void syscall_handler(struct intr_frame *f UNUSED)
 		}
 
 		case SYS_OPEN:
-			break;
+			uint64_t user_file = f->R.rdi;
+			check_valid_pointer(user_file, sizeof(user_file));
+			check_valid_str(user_file);
+			// 파일 이름을 받아 파일 시스템에서 해당 파일을 찾고, 열린 파일 객체를 만들어 리턴하는 함수
+			struct file * kernel_file = filesys_open(user_file); 
 
+			if(kernel_file == NULL) //실패한경우
+			{
+				f->R.rax = -1;
+			}
+			else //성공한경우
+			{
+				int fdt_number = process_add_file(kernel_file);
+				if (fdt_number == -1) // 실패한경우
+				{
+					file_close(kernel_file); 
+				}
+				f->R.rax = fdt_number;
+			}
+			return;
 		case SYS_FILESIZE:{
 			// file.c 에 file_length(file *)
 			// file 안에 있는 바이트 개수를 반환하는 함수 사용
@@ -295,8 +313,7 @@ void syscall_handler(struct intr_frame *f UNUSED)
 			break;
 
 		case SYS_CLOSE:
-			break;
-
+			process_close_file(f->R.rdi); //해당 fd 닫기
 		default:
 			break;
 	}


### PR DESCRIPTION
## 요약
`feat-#28` 브랜치의 syscall 변경 사항을 PR로 올립니다.

## 변경 사항
- `SYS_OPEN`에서 파일명을 검증하고 `filesys_open()` 결과를 fd table에 등록합니다.
- `SYS_CLOSE`에서 전달받은 fd를 닫도록 연결합니다.

## 테스트
- 별도 테스트는 실행하지 않았습니다.

## 비고
- 사용자 요청에 따라 현재 작업 내용을 그대로 커밋해 올렸습니다.

Closes #28
