### PR TITLE
feat: exec 시스템콜과 실행 전환 흐름 구현

### DIFF
--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -355,9 +355,6 @@ int process_exec(void *f_name)
  * does nothing. */
 int process_wait(tid_t child_tid UNUSED)
 {
-	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
-	 * XXX:       to add infinite loop here before
-	 * XXX:       implementing the process_wait. */
 	while (true)
 	{
 		thread_yield();

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -25,7 +25,6 @@ void handle_sys_halt(struct intr_frame *f);
 void handle_sys_exit(struct intr_frame *f);
 void handle_sys_fork(struct intr_frame *f);
 void handle_sys_exec(struct intr_frame *f);
-void handle_sys_wait(struct intr_frame *f);
 void handle_sys_create(struct intr_frame *f);
 void handle_sys_remove(struct intr_frame *f);
 void handle_sys_open(struct intr_frame *f);
@@ -205,9 +204,7 @@ void handle_sys_exec(struct intr_frame *f)
 		아래 조건문을 넣어 주는 이유
 		즉, process_exec가 실패해서 돌아왔을때, 기존 유저 프로그램으로 정상적으로 복귀할 수 없기 때문에
 		page fault가 발생한다
-
-		임시로 넣어준 조건문
-		=> 수정해야 할 부분 : process_exec()가 기존 주소 공간을 지우기 전에, load 성공 여부를 체크 한 다음에 지운다.
+		그래서 실패하면 thread_exit()으로 종료시킨다.
 	*/
     if (process_exec(file_copy) < 0)
 	{

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -1,5 +1,6 @@
 #include "userprog/syscall.h"
 #include <stdio.h>
+#include <string.h>
 #include <syscall-nr.h>
 #include "threads/interrupt.h"
 #include "threads/thread.h"
@@ -9,6 +10,7 @@
 #include "intrinsic.h"
 #include "kernel/stdio.h"
 #include "threads/init.h"
+#include "threads/palloc.h"
 #include "userprog/process.h"
 #include "filesys/filesys.h"
 #include "devices/input.h"
@@ -18,10 +20,12 @@ void syscall_entry(void);
 void syscall_handler(struct intr_frame *);
 void check_valid_addr(void *addr);
 void check_valid_pointer(void *start, size_t size);
-void check_valid_str(char *str);
+void check_valid_str(const char *str);
 void handle_sys_halt(struct intr_frame *f);
 void handle_sys_exit(struct intr_frame *f);
 void handle_sys_fork(struct intr_frame *f);
+void handle_sys_exec(struct intr_frame *f);
+void handle_sys_wait(struct intr_frame *f);
 void handle_sys_create(struct intr_frame *f);
 void handle_sys_remove(struct intr_frame *f);
 void handle_sys_open(struct intr_frame *f);
@@ -147,9 +151,69 @@ void handle_sys_write(struct intr_frame *f)
 
 void handle_sys_fork(struct intr_frame *f)
 {
-	char *name = f->R.rdi;
+	const char *name = (const char *)f->R.rdi;
 	check_valid_str(name);
 	f->R.rax = process_fork(name, f);
+}
+
+void handle_sys_exec(struct intr_frame *f)
+{
+    const char *file = (const char *) f->R.rdi;
+
+    check_valid_str(file);
+
+	// exec는 기존 프로그램의 유저 메모리 공간을 버리고, 새 프로그램의 메모리 공간으로 교체하기 위함
+	// exec는 새로운 프로세스를 만드는게 아니다. fork X
+	// 현재 프로세스가 실행하던 프로그램을 새 프로그램으로 바꾸는 작업
+
+	/*
+		exec() 호출 흐름
+		기존 프로그램이 돌아가고 있다 -> CPU가 현재 프로세스의 pml4를 기준으로 가상주소를 매핑하고 있다.
+		-> exec()를 호출
+		-> process_cleanup() = 기존의 pml4를 해제한다.
+		-> load() => 새로운 pml4 를 생성한다(새로운 프로그램의 코드영역/데이터영역/스택영역을 채운다.)
+		-> do_iret() => 새롭게 만들어진 프로그램을 유저 영역으로 넘김
+	*/
+
+	/*
+		cleanup()을 하는 이유?
+		-> 기존 프로그램의 pt(가상주소를 물리 주소에 매핑)이 남아있는 상태에서 새 프로그램을 같은 가상주소에 올리게 된다. 이러면 안됨.
+	*/
+
+	/*
+		그대로 rdi를 안넘겨주고, 카피본을 뜬 다음 그걸 인자로 넘겨주는 이유가 중요하다.
+		프로그램이 실행중에 exec("~") 를 호출하면 "~" 문자열은 유저 프로그램의 메모리 어딘가에 남아있다.
+		rdi에 "~"의 주소가 들어가 있고, 해당 프로세스의 PT는 "~"의 가상주소를 물리 페이지에 매핑하는 정보를 가지고 있다.
+		이 상태에서 rdi 를 복사하지 않고, 그대로 인자로 넘겨버리게 되면 위에서 설명한 cleanup() 후에는 해당 rdi에 있는 값을 찾을 수 없다.
+		load() 에서는 불러오고자 하는 file_name을 인자로 받는데, 이렇게 되면 "~" 값이 아니라 invalid한 값을 읽어버리게 되서 잘못된 동작을 하거나 fault 가 발생한다.
+	*/
+		
+	/*
+		위와 같은 상황을 막기 위해, file_name을 어딘가에 따로 복사를 해두고 그걸 인자로 넘겨줘야 한다.
+		cleanup()을 할 때, 사라지지 않고 안전한 곳 => 커널 영역의 페이지, 즉 palloc_get_page(0)으로 할당한 커널 페이지
+		생성한 커널 페이지에 file_name을 복사해두고, 이걸 exec()의 인자로 넘기면 clean 해도 유저 영역만 제거되고 커널 페이지는 살아남는다.
+	*/
+    char *file_copy = palloc_get_page(0);
+    if (file_copy == NULL) {
+        f->R.rax = -1;
+        return;
+    }
+
+    strlcpy(file_copy, file, PGSIZE);
+
+	/*
+		아래 조건문을 넣어 주는 이유
+		즉, process_exec가 실패해서 돌아왔을때, 기존 유저 프로그램으로 정상적으로 복귀할 수 없기 때문에
+		page fault가 발생한다
+
+		임시로 넣어준 조건문
+		=> 수정해야 할 부분 : process_exec()가 기존 주소 공간을 지우기 전에, load 성공 여부를 체크 한 다음에 지운다.
+	*/
+    if (process_exec(file_copy) < 0)
+	{
+		thread_current()->exit_status = -1;
+		thread_exit();
+	}
 }
 
 void handle_sys_create(struct intr_frame *f)
@@ -307,7 +371,7 @@ void handle_sys_close(struct intr_frame *f)
 	process_close_file((int)f->R.rdi); // 해당 fd 닫기
 }
 
-void check_valid_str(char *str) {
+void check_valid_str(const char *str) {
     for (int i = 0;; i++) {
         check_valid_addr(&str[i]);
         if (str[i] == '\0')
@@ -336,6 +400,7 @@ void syscall_handler(struct intr_frame *f UNUSED)
 		break;
 
 	case SYS_EXEC:
+		handle_sys_exec(f);
 		break;
 
 	case SYS_WAIT:


### PR DESCRIPTION
﻿## 요약
`exec()` 시스템콜을 구현해 현재 실행 중인 user program이 새로운 사용자 프로그램으로 자신의 실행 문맥을 교체할 수 있도록 했습니다.

리뷰어가 보면 알 수 있도록 핵심 의도를 먼저 정리하면 아래와 같습니다.
- `exec`는 `fork`처럼 새 프로세스를 하나 더 만드는 동작이 아니라, 현재 프로세스가 들고 있던 사용자 주소 공간을 버리고 새 프로그램의 주소 공간으로 갈아끼우는 동작입니다.
- 이 과정에서 사용자 메모리에 있던 `file_name` 포인터를 그대로 넘기면, 기존 주소 공간 정리 이후에는 더 이상 안전하게 참조할 수 없기 때문에 커널 메모리로 복사한 뒤 실행 흐름에 넘기도록 했습니다.
- 호출자 입장에서는 실행 성공 시 새 프로그램으로 진입하고, 실패 시에도 일관된 실패 처리 규칙을 따르도록 흐름을 정리했습니다.

## 변경 사항
### 1. `exec()` 시스템콜 진입 경로 추가
- `syscall_handler()`에 `SYS_EXEC` 분기를 연결했습니다.
- `handle_sys_exec()`에서 사용자로부터 받은 파일명 포인터를 문자열 단위로 검증한 뒤 실행을 시작하도록 했습니다.
- `check_valid_str()`를 통해 문자열 끝(`'\0'`)까지 안전하게 접근 가능한지 확인하도록 정리했습니다.

### 2. 사용자 포인터를 그대로 쓰지 않고 커널 페이지에 복사하도록 변경
- `exec()`는 내부적으로 기존 사용자 주소 공간을 정리한 뒤 새 프로그램을 적재합니다.
- 따라서 사용자 스택이나 사용자 메모리에 있던 파일명 포인터를 그대로 `process_exec()`에 넘기면, 정리 이후에는 해당 주소가 더 이상 유효하지 않을 수 있습니다.
- 이를 피하기 위해 `palloc_get_page(0)`으로 커널 페이지를 확보하고, 실행 파일 이름 문자열을 그 공간에 복사한 뒤 `process_exec()`로 전달하도록 했습니다.
- 이 부분은 이번 PR의 핵심 설계 포인트라서, 구현보다도 메모리 생존 범위를 어떻게 보장했는지가 중요합니다.

### 3. `process_exec()`와 `load()`를 `exec` 흐름에 맞게 연결
- `process_exec()`에서 현재 프로세스의 실행 문맥을 정리하고, 새 ELF 바이너리를 적재한 뒤 사용자 영역으로 다시 진입하는 흐름을 구성했습니다.
- `load()`에서는 command line 전체를 파싱해 실제 실행 파일 이름과 인자를 분리하도록 했습니다.
- 실행 파일은 파싱된 첫 토큰 기준으로 열고, 이후 인자들은 사용자 스택에 재배치해 새 프로그램이 기대하는 형태로 전달되도록 했습니다.

### 4. 인자 전달(argument passing)까지 한 흐름으로 정리
- `exec("prog arg1 arg2")` 형태를 처리할 수 있도록 command line을 토큰화했습니다.
- 사용자 스택에는 인자 문자열, 포인터 배열, 정렬 패딩, `argv` 시작 주소가 들어가도록 구성했습니다.
- 그 결과 새 프로그램은 단순히 진입만 하는 것이 아니라, 인자 정보까지 포함된 정상적인 실행 컨텍스트를 받게 됩니다.
- 이 변경은 `exec`를 실제로 사용할 수 있게 만드는 필수 기반 작업이라 PR 범위에 함께 포함했습니다.

## 리뷰 포인트
- `exec`가 "새 프로세스 생성"이 아니라 "현재 프로세스의 주소 공간 교체"라는 전제를 구현 흐름에 맞게 반영했는지
- 사용자 포인터를 커널 페이지로 복사하는 이유와 시점이 타당한지
- `load()`에서 파일명 파싱과 인자 적재가 리뷰어가 기대하는 Pintos 규약과 어긋나지 않는지
- 실패 시 `-1` 처리와 종료 처리 방식이 일관적인지
- 파일 디스크립터 헬퍼 추가가 기존 file syscall 흐름과 자연스럽게 맞물리는지


## 비고
- 이번 PR은 우선 `exec`의 핵심 실행 경로를 연결하고, 잘못된 사용자 영역 참조를 피하는 데 필요한 방어 로직과 실행 준비 작업을 함께 정리한 변경으로 봐주시면 좋겠습니다.

Closes #34
