### PR TITLE
feat: 자식 프로세스 wait 상태 관리 추가

### DIFF
--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -134,6 +134,8 @@ struct thread
 	struct file * fdt[FDT_SIZE]; //각 파일을 가리키는 인덱스 128짜리 fdt테이블 생성
 	int next_fd;
 
+	//
+
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
 	uint64_t *pml4; /* Page map level 4 */

--- a/pintos/include/threads/thread.h
+++ b/pintos/include/threads/thread.h
@@ -5,6 +5,7 @@
 #include <list.h>
 #include <stdint.h>
 #include "threads/interrupt.h"
+#include "synch.h"
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -49,6 +50,15 @@ typedef int fixed_t; // 고정 소수점 type 정의
 
 #define NICE_MAX 20
 #define NICE_MIN -20
+
+struct child_status // 자식 정보 담을 구조체
+{
+	tid_t tid;					// 자식 프로세스 tid
+	int exit_status;			// 자식이 종료할 때 남긴 코드
+	bool waited;				// 이미 wait가 호출이 됐는지
+	struct semaphore exit_sema; // 부모가 자식이 끝날때 까지 잠들기 위한 세마포어
+	struct list_elem elem;		// child_status를 부모의 자식 리스트에 넣기 위함
+};
 
 /* A kernel thread or user process.
  *
@@ -133,8 +143,7 @@ struct thread
 	//File Descriptor
 	struct file * fdt[FDT_SIZE]; //각 파일을 가리키는 인덱스 128짜리 fdt테이블 생성
 	int next_fd;
-
-	//
+	
 
 #ifdef USERPROG
 	/* Owned by userprog/process.c. */
@@ -143,7 +152,10 @@ struct thread
 		그냥 status에 exit status를 저장하면 안된다고 한다.
 		status 는 스레드가 실행 중인지/죽는 중인지 의 상태를 저장하는 곳이고,
 		exit_status를 따로 할당해서 프로그램이 exit(int)로 종료했다 의 상태를 저장하는 곳이다.
-	*/
+		*/
+
+	struct child_status *child_status; // child_status 구조체 가리키는포인터
+	struct list children;
 	int exit_status;
 #endif
 #ifdef VM

--- a/pintos/threads/thread.c
+++ b/pintos/threads/thread.c
@@ -660,6 +660,8 @@ init_thread (struct thread *t, const char *name, int priority) // thread 구조�
 	t->exit_status = -1;
 	t->next_fd = 2;
 	//Read, write에서 각각 fdt[0], fdt[1]이면 키보드입력, 콘솔 출력처리
+	list_init(&t->children);
+	t->child_status = NULL;
 }
 
 /* Chooses and returns the next thread to be scheduled.  Should

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -25,7 +25,7 @@
 
 static void process_cleanup(void);
 static bool load(const char *file_name, struct intr_frame *if_);
-static void initd(void *f_name);
+static void initd(void * aux);
 static void __do_fork(void *);
 static bool duplicate_fd_table(struct thread *parent, struct thread *child);
 
@@ -112,7 +112,7 @@ tid_t process_create_initd(const char *file_name)
 static void
 initd(void * aux)
 {
-	struct initd_args *args = aux;
+	struct initd_args *args = (struct initd_args *)aux;
 	char *f_name = args->file_name;
 
 	thread_current()->child_status = args->cs;
@@ -171,16 +171,19 @@ tid_t process_fork(const char *name, struct intr_frame *if_ UNUSED)
 
 	//스레드 생성 성공하면
 	cs->tid = tid;
-	list_push_back(&thread_current()->children, &cs->elem);
 
 	sema_down(&fa->fork_sema); // 자식이 만들어질 때까지 기다림
 
 	if (!fa->success)
 	{
-		list_remove(&cs->elem);
 		free(cs);
 		tid = TID_ERROR;
 	}
+	else
+	{
+		list_push_back(&thread_current()->children, &cs->elem);
+	}
+
 	free(fa);
 	return tid;
 }
@@ -339,7 +342,6 @@ __do_fork(void *aux)
 	struct fork_args *fa = (struct fork_args *)aux;
 	struct thread *current = thread_current();
 	struct thread *parent = fa->parent;
-	current -> child_status = fa->cs; //부모에게 전달할 상태 저장
 	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
 	struct intr_frame *parent_if = &fa->if_;
 
@@ -372,6 +374,8 @@ __do_fork(void *aux)
 	}
 
 	/* Finally, switch to the newly created process. */
+	current->child_status = fa->cs; // 부모에게 전달할 상태 저장
+	
 	if_.R.rax = 0; // 자식 쓰레드(프로세스) 반환 0
 	fa->success = true;
 	sema_up(&fa->fork_sema);

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -358,10 +358,7 @@ int process_wait(tid_t child_tid UNUSED)
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
-	while (true)
-	{
-		thread_yield();
-	}
+
 	return -1;
 }
 

--- a/pintos/userprog/process.c
+++ b/pintos/userprog/process.c
@@ -35,6 +35,12 @@ struct fork_args
 	struct intr_frame if_;
 	struct semaphore fork_sema;
 	bool success;
+	struct child_status *cs;
+};
+
+struct initd_args {
+	char * file_name;
+	struct child_status * cs;
 };
 
 /* General process initializer for initd and other process. */
@@ -53,7 +59,7 @@ tid_t process_create_initd(const char *file_name)
 {
 	char *fn_copy;
 	tid_t tid;
-
+	
 	/* Make a copy of FILE_NAME.
 	 * Otherwise there's a race between the caller and load(). */
 	fn_copy = palloc_get_page(0);
@@ -61,17 +67,57 @@ tid_t process_create_initd(const char *file_name)
 		return TID_ERROR;
 	strlcpy(fn_copy, file_name, PGSIZE);
 
-	/* Create a new thread to execute FILE_NAME. */
-	tid = thread_create(file_name, PRI_DEFAULT, initd, fn_copy);
-	if (tid == TID_ERROR)
+	//init create에도 똑같이 표지판 생성
+	struct child_status *cs = malloc(sizeof(struct child_status));
+	if (cs == NULL)
+	{
 		palloc_free_page(fn_copy);
+		return TID_ERROR;
+	}
+
+	struct initd_args *args = malloc(sizeof(struct initd_args));
+	if (args == NULL)
+	{
+		free(cs);
+		palloc_free_page(fn_copy);
+		return TID_ERROR;
+	}
+
+	cs->tid = TID_ERROR;
+	cs->exit_status = -1;
+	cs->waited = false;
+	sema_init(&cs->exit_sema, 0);
+
+	args->file_name = fn_copy;
+	args->cs = cs;
+
+	/* Create a new thread to execute FILE_NAME. */
+	tid = thread_create(file_name, PRI_DEFAULT, initd, args);
+	if (tid == TID_ERROR)
+	{
+		free(args);
+		free(cs);
+		palloc_free_page(fn_copy);
+		return TID_ERROR;
+	}
+
+	cs->tid = tid;
+	list_push_back(&thread_current()->children, &cs->elem);
+
 	return tid;
 }
 
+
 /* A thread function that launches first user process. */
 static void
-initd(void *f_name)
+initd(void * aux)
 {
+	struct initd_args *args = aux;
+	char *f_name = args->file_name;
+
+	thread_current()->child_status = args->cs;
+	free(args);
+	
 #ifdef VM
 	supplemental_page_table_init(&thread_current()->spt);
 #endif
@@ -89,8 +135,17 @@ tid_t process_fork(const char *name, struct intr_frame *if_ UNUSED)
 {
 	/* Clone current thread to new thread.*/
 	struct fork_args *fa = (struct fork_args *)malloc(sizeof(struct fork_args));
+	
 	if (fa == NULL)
 	{
+		return TID_ERROR;
+	}
+
+	// child_status세팅
+	struct child_status *cs = malloc(sizeof(struct child_status)); // child status 할당
+	if (cs == NULL)												   // 잘못되면
+	{
+		free(fa);
 		return TID_ERROR;
 	}
 
@@ -98,18 +153,32 @@ tid_t process_fork(const char *name, struct intr_frame *if_ UNUSED)
 	memcpy(&(fa->if_), if_, sizeof(struct intr_frame));
 	sema_init(&fa->fork_sema, 0);
 	fa->success = false;
+
+	cs->tid = TID_ERROR; //임시값
+	cs->exit_status = -1;
+	cs->waited = false;
+	sema_init(&cs->exit_sema, 0);
+	fa->cs = cs; //fa에 cs도 삽입
+
 	tid_t tid = thread_create(name, PRI_DEFAULT, __do_fork, fa);
 
-	if (tid == TID_ERROR)
+	if(tid == TID_ERROR)
 	{
+		free(cs);
 		free(fa);
 		return TID_ERROR;
 	}
+
+	//스레드 생성 성공하면
+	cs->tid = tid;
+	list_push_back(&thread_current()->children, &cs->elem);
 
 	sema_down(&fa->fork_sema); // 자식이 만들어질 때까지 기다림
 
 	if (!fa->success)
 	{
+		list_remove(&cs->elem);
+		free(cs);
 		tid = TID_ERROR;
 	}
 	free(fa);
@@ -270,6 +339,7 @@ __do_fork(void *aux)
 	struct fork_args *fa = (struct fork_args *)aux;
 	struct thread *current = thread_current();
 	struct thread *parent = fa->parent;
+	current -> child_status = fa->cs; //부모에게 전달할 상태 저장
 	/* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
 	struct intr_frame *parent_if = &fa->if_;
 
@@ -358,8 +428,34 @@ int process_wait(tid_t child_tid UNUSED)
 	/* XXX: Hint) The pintos exit if process_wait (initd), we recommend you
 	 * XXX:       to add infinite loop here before
 	 * XXX:       implementing the process_wait. */
+	struct thread * pt = thread_current(); //부모 프로세스
+	struct child_status * target = NULL; //pt children 리스트에서 찾을 특정 자식의 child_status
 
-	return -1;
+	struct list_elem *e;
+	// 부모의 children list를 순회
+	for(e = list_begin(&pt -> children); e != list_end(&pt -> children); e = list_next(e)) 
+	{
+		struct child_status *cs = list_entry(e, struct child_status, elem);
+		if(cs -> tid == child_tid)
+		{
+			target = cs;
+			break;
+		}
+	}
+
+	if(target == NULL) { return -1; } 
+	if(target->waited) { return -1; } //이미 waited된적 있으면 
+
+	target->waited = true;
+
+	sema_down(&target->exit_sema); //자식이 끝날때까지 재움
+
+	int exit_status = target->exit_status;
+
+	list_remove(&target->elem);
+	free(target);
+
+	return exit_status;
 }
 
 /* Exit the process. This function is called by thread_exit (). */
@@ -380,6 +476,12 @@ void process_exit(void)
 	{
 		printf("%s: exit(%d)\n", curr->name, curr->exit_status);
 		process_close_all_files();
+	}
+
+	if(curr -> child_status != NULL)
+	{
+		curr->child_status->exit_status = curr->exit_status;
+		sema_up(&curr->child_status->exit_sema);
 	}
 	process_cleanup();
 }

--- a/pintos/userprog/syscall.c
+++ b/pintos/userprog/syscall.c
@@ -307,6 +307,11 @@ void handle_sys_close(struct intr_frame *f)
 	process_close_file((int)f->R.rdi); // 해당 fd 닫기
 }
 
+void handle_sys_wait(struct intr_frame * f)
+{
+	f->R.rax = process_wait(f->R.rdi);
+}
+
 void check_valid_str(char *str) {
     for (int i = 0;; i++) {
         check_valid_addr(&str[i]);
@@ -339,6 +344,7 @@ void syscall_handler(struct intr_frame *f UNUSED)
 		break;
 
 	case SYS_WAIT:
+		handle_sys_wait(f);
 		break;
 
 	case SYS_CREATE:


### PR DESCRIPTION
## 요약
자식 프로세스의 종료 상태를 부모가 추적하고 `process_wait()`에서 회수할 수 있도록 기본 구조를 추가했습니다.

## 변경 사항
- `struct child_status`를 추가해 자식 tid, exit status, wait 여부, 종료 대기 세마포어를 관리합니다.
- thread 초기화 시 children 리스트와 child_status 포인터를 초기화합니다.
- `process_create_initd()`와 `process_fork()`에서 자식 상태 구조체를 생성하고 부모 children 리스트에 연결합니다.
- `process_wait()`에서 자식 종료를 기다린 뒤 exit status를 반환하도록 구현합니다.
- `process_exit()`에서 부모가 기다리는 child_status에 종료 상태를 전달하고 세마포어를 깨웁니다.

## 테스트
- `git diff --check` 실행: trailing whitespace 경고가 있어 실패했습니다.

## 비고
- 사용자 요청에 따라 현재 작업 내용을 코드 수정 없이 그대로 커밋해 올렸습니다.

Closes #28
